### PR TITLE
Remove `did_evict` loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@
 # Python
 __pycache__/
 *.py[cod]
+
+# VS Code
+/.vscode/
+/build/

--- a/unified_cache.cpp
+++ b/unified_cache.cpp
@@ -46,17 +46,7 @@ bool cache_partition::insert(torrent_location const &loc, char const *data, int 
 	// New entry - try to evict if at capacity
 	// libtorrent 2.x design: allow over-allocation (short-term exceeding max_entries)
 	// This prevents blocking writes when all entries are temporarily dirty
-	bool did_evict = false;
-	while (m_entries.size() >= m_max_entries) {
-		if (!evict_one_lru()) {
-			// Cannot evict (all clean entries exhausted)
-			// Allow over-allocation - insert anyway
-			spdlog::debug("[cache_partition] Over-allocation: size={}, max={}",
-				m_entries.size() + 1, m_max_entries);
-			break;
-		}
-		did_evict = true;
-	}
+	bool did_evict = m_entries.size() >= m_max_entries;
 
 	// Allocate new buffer (cache manages its own memory)
 	char *buffer = static_cast<char *>(malloc(DEFAULT_BLOCK_SIZE));

--- a/unified_cache.cpp
+++ b/unified_cache.cpp
@@ -43,6 +43,7 @@ bool cache_partition::insert(torrent_location const &loc, char const *data, int 
 		return true;
 	}
 
+	evict_one_lru();
 	// New entry - try to evict if at capacity
 	// libtorrent 2.x design: allow over-allocation (short-term exceeding max_entries)
 	// This prevents blocking writes when all entries are temporarily dirty

--- a/unified_cache.cpp
+++ b/unified_cache.cpp
@@ -43,11 +43,12 @@ bool cache_partition::insert(torrent_location const &loc, char const *data, int 
 		return true;
 	}
 
-	evict_one_lru();
 	// New entry - try to evict if at capacity
 	// libtorrent 2.x design: allow over-allocation (short-term exceeding max_entries)
 	// This prevents blocking writes when all entries are temporarily dirty
-	bool did_evict = m_entries.size() >= m_max_entries;
+	if (m_entries.size() >= m_max_entries) {
+		evict_one_lru();
+	}
 
 	// Allocate new buffer (cache manages its own memory)
 	char *buffer = static_cast<char *>(malloc(DEFAULT_BLOCK_SIZE));


### PR DESCRIPTION
1. I'm unsure if this should close #125.
2. `did_evict` is now only used by commented code.