### PR TITLE
perf(raw_disk_io): chunk-aligned read prefetch for seeder upload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,54 @@
   - Replaced ezio_ui.py with refactored version, removed obsolete files
   - Net result: -743 lines of code with more features
 
+**📊 Prefetch Chunk Size Investigation (2026-05-22)**
+
+Branch: `feat/seeder-prefetch`. Investigated whether the seeder-side
+chunk-aligned read prefetch (`raw_disk_io.cpp` `async_read` chunk path,
+introduced by `f809ae8`) should derive its chunk size from cache size, or
+use a fixed value. Final answer: **fixed `m_prefetch_blocks = 16`** (commit
+`e2324f8`).
+
+Method: distributed benchmark, 1 seeder + 3 leechers, 60.6 GiB partclone
+torrent on raw NVMe (SX8200 Pro, SLC > 100 GB), `blkdiscard` between runs
+to remove SLC noise. Scripts kept in `tests/distrib_test/` (working tree
+only, not committed); raw logs in `tmp/distrib_test_results/`.
+
+Key findings:
+
+- The previous formula `entries_per_partition / 4` scaled chunk size with
+  cache memory, which is **wrong**. Right size is set by libtorrent's
+  per-piece peer-request pipeline depth (~16 outstanding blocks), not by
+  how much cache memory there is.
+
+- At cache=512 MB the derived formula gave chunk=512 blocks (8 MiB),
+  which crashed `actual_dl` to 289s and dropped leecher cache hit to
+  ~94% via partition eviction (each chunk insert evicts 25% of partition
+  entries). Fixed chunk=16 brought it back to 173s with 99-100% hit rate.
+
+- 2D sweep across cache sizes 512 MB / 2 / 4 / 8 GB and chunk sizes
+  1 / 4 / 8 / 16 / 32 / 64 / 256 / 512 / 2048 / 4096 / 8192 confirmed
+  `chunk=16` is the best or tied-for-best in every cell, and is the
+  smallest chunk that is never the worst.
+
+- async_hash cache warming (commit `57c3b7e`) is responsible for the
+  bulk of the seeder cache hit rate jump (16% on raw master -> 60% with
+  warming). Pure chunk-prefetch alone (no async_hash warming) gets
+  seeder hit to 53% (chunk=1) / 97% (chunk=16) / 99.5% (chunk=512) but
+  requires `disable_hash_checks=true` and so trades BT integrity for
+  speed.
+
+- Considered but rejected: deeper refactors of async_hash (chunk-batch
+  the inner read loop using a 16 MiB thread_local piece buffer; offload
+  SHA1 to a 2-4 thread hash pool). Both would shave another ~5-15s off
+  the 170s baseline, but the maintenance cost (three probe-and-decide
+  paths, thread_local memory, two-pool coordination) was judged too
+  high for the gain. Sticking with the simple constant chunk size.
+
+- Side: `partition_storage` could in principle batch its per-`file_slice`
+  preads via `preadv(2)`; analysis (Issue #136) showed <2% syscall win
+  for the current torrent profile and the issue is closed.
+
 **🔧 Recent Maintenance & Fixes (2025-12-27):**
 - 🔧 **Lambda Capture Fix** (commit: 3a5dd32)
   - Removed redundant 'this' capture in lambda expressions

--- a/partition_storage.cpp
+++ b/partition_storage.cpp
@@ -18,6 +18,11 @@ partition_storage::partition_storage(const std::string &path, libtorrent::file_s
 		spdlog::critical("failed to open ({}) = {}", path, strerror(m_fd));
 		exit(1);
 	}
+
+	int rc = posix_fadvise(m_fd, 0, 0, POSIX_FADV_SEQUENTIAL);
+	if (rc != 0) {
+		spdlog::warn("posix_fadvise(SEQUENTIAL) failed on {}: {}", path, strerror(rc));
+	}
 }
 
 partition_storage::~partition_storage()

--- a/raw_disk_io.cpp
+++ b/raw_disk_io.cpp
@@ -68,15 +68,15 @@ raw_disk_io::raw_disk_io(libtorrent::io_context &ioc,
 	size_t cache_entries = calculate_cache_entries(sett);
 	size_t entries_per_partition = cache_entries / m_num_io_threads;
 
-	// Derive prefetch chunk size from cache partition size
-	constexpr size_t PREFETCH_DIVISOR = 4;
-	constexpr size_t MIN_PREFETCH_BLOCKS = 16;
-	m_prefetch_blocks = std::max(MIN_PREFETCH_BLOCKS,
-		entries_per_partition / PREFETCH_DIVISOR);
-	spdlog::info("[raw_disk_io] Prefetch: {} blocks ({} KB) per chunk "
-				 "(derived from {} entries/partition / {})",
-		m_prefetch_blocks, m_prefetch_blocks * 16,
-		entries_per_partition, PREFETCH_DIVISOR);
+	// Prefetch chunk size: fixed at 16 blocks (256 KiB).
+	// A 256 KiB chunk roughly matches a libtorrent peer's per-piece request
+	// pipeline depth, amortises the pread syscall cost without polluting the
+	// cache. Sweeps across cache sizes 512 MB..8 GB showed 16 to be the
+	// best or tied-for-best value (and the only value that is never the
+	// worst); larger chunks degrade hit rate via partition eviction.
+	m_prefetch_blocks = 16;
+	spdlog::info("[raw_disk_io] Prefetch: {} blocks ({} KB) per chunk",
+		m_prefetch_blocks, m_prefetch_blocks * 16);
 
 	spdlog::info("[raw_disk_io] Buffer pools initialized:");
 	spdlog::info("  Read pool:  {} MB ({} buffers)",

--- a/raw_disk_io.cpp
+++ b/raw_disk_io.cpp
@@ -390,6 +390,9 @@ void raw_disk_io::async_hash(
 					ret = st->read(buf, piece, offset, len, error);
 					if (ret > 0) {
 						ph.update(buf, ret);
+						// Free pre-warm: cache the block we just hashed.
+						// Safe even if hash later fails — async_clear_piece will drop bad pieces.
+						m_cache.insert_read({storage, piece, offset}, buf, ret);
 					}
 				}
 

--- a/raw_disk_io.cpp
+++ b/raw_disk_io.cpp
@@ -242,8 +242,7 @@ void raw_disk_io::async_read(
 					int missing = 0;
 					for (int i = chunk_start_idx; i < chunk_end_idx; ++i) {
 						int off = i * DEFAULT_BLOCK_SIZE;
-						if (!m_cache.get({idx, r.piece, off}, [](char const *) {
-							})) {
+						if (!m_cache.has({idx, r.piece, off})) {
 							++missing;
 						}
 					}
@@ -279,8 +278,7 @@ void raw_disk_io::async_read(
 							for (int i = chunk_start_idx; i < chunk_end_idx; ++i) {
 								int const off = i * DEFAULT_BLOCK_SIZE;
 								torrent_location loc{idx, r.piece, off};
-								if (m_cache.get(loc, [](char const *) {
-									}))
+								if (m_cache.has(loc))
 									continue;
 								int const block_bytes_into_chunk =
 									(i - chunk_start_idx) * DEFAULT_BLOCK_SIZE;

--- a/raw_disk_io.cpp
+++ b/raw_disk_io.cpp
@@ -229,22 +229,100 @@ void raw_disk_io::async_read(
 				});
 
 				if (!cache_hit) {
-					// Cache miss - read from disk
-					auto const start_time = libtorrent::clock_type::now();
-					m_storages[idx]->read(buf, r.piece, r.start, r.length, error);
-					auto const read_time = libtorrent::total_microseconds(libtorrent::clock_type::now() - start_time);
+					// Determine piece geometry for chunk-aligned prefetch
+					int const piece_size = m_storages[idx]->piece_size(r.piece);
+					int const blocks_in_piece = (piece_size + DEFAULT_BLOCK_SIZE - 1) / DEFAULT_BLOCK_SIZE;
+					int const this_block_idx = block_offset / DEFAULT_BLOCK_SIZE;
 
-					m_stats_counters.inc_stats_counter(libtorrent::counters::num_read_ops);
-					m_stats_counters.inc_stats_counter(libtorrent::counters::disk_read_time, read_time);
-					m_stats_counters.inc_stats_counter(libtorrent::counters::disk_job_time, read_time);
+					int const n = std::min<int>(static_cast<int>(m_prefetch_blocks), blocks_in_piece);
+					int const chunk_start_idx = (this_block_idx / n) * n;
+					int const chunk_end_idx = std::min(chunk_start_idx + n, blocks_in_piece);
 
-					// Insert into cache (clean) for future reads
-					if (!error) {
-						m_cache.insert_read({idx, r.piece, block_offset}, buf, r.length);
+					// Probe how many blocks in the chunk are missing from cache
+					int missing = 0;
+					for (int i = chunk_start_idx; i < chunk_end_idx; ++i) {
+						int off = i * DEFAULT_BLOCK_SIZE;
+						if (!m_cache.get({idx, r.piece, off}, [](char const *) {
+							})) {
+							++missing;
+						}
 					}
-				}
+					int const chunk_blocks = chunk_end_idx - chunk_start_idx;
 
-				m_stats_counters.inc_stats_counter(libtorrent::counters::num_blocks_read);
+					if (missing * 4 >= chunk_blocks * 3) {
+						// >= 75% of chunk is missing: whole-chunk pread + bulk insert
+						thread_local std::vector<char> tls_chunk_buf;
+						size_t const need = size_t(n) * DEFAULT_BLOCK_SIZE;
+						if (tls_chunk_buf.size() < need)
+							tls_chunk_buf.resize(need);
+
+						int const chunk_offset_bytes = chunk_start_idx * DEFAULT_BLOCK_SIZE;
+						int const chunk_size_bytes = std::min<int>(
+							chunk_blocks * DEFAULT_BLOCK_SIZE,
+							piece_size - chunk_offset_bytes);
+
+						auto const start_time = libtorrent::clock_type::now();
+						int chunk_ret = m_storages[idx]->read(
+							tls_chunk_buf.data(), r.piece,
+							chunk_offset_bytes, chunk_size_bytes, error);
+						auto const read_time =
+							libtorrent::total_microseconds(libtorrent::clock_type::now() - start_time);
+
+						m_stats_counters.inc_stats_counter(libtorrent::counters::num_read_ops);
+						m_stats_counters.inc_stats_counter(libtorrent::counters::disk_read_time, read_time);
+						m_stats_counters.inc_stats_counter(libtorrent::counters::disk_job_time, read_time);
+						m_stats_counters.inc_stats_counter(
+							libtorrent::counters::num_blocks_read, chunk_blocks);
+
+						if (chunk_ret > 0 && !error) {
+							// Bulk insert each block, skipping already-cached entries
+							for (int i = chunk_start_idx; i < chunk_end_idx; ++i) {
+								int const off = i * DEFAULT_BLOCK_SIZE;
+								torrent_location loc{idx, r.piece, off};
+								if (m_cache.get(loc, [](char const *) {
+									}))
+									continue;
+								int const block_bytes_into_chunk =
+									(i - chunk_start_idx) * DEFAULT_BLOCK_SIZE;
+								int const this_block_len = std::min<int>(
+									DEFAULT_BLOCK_SIZE,
+									chunk_size_bytes - block_bytes_into_chunk);
+								if (this_block_len <= 0)
+									break;
+								m_cache.insert_read(
+									loc,
+									tls_chunk_buf.data() + block_bytes_into_chunk,
+									this_block_len);
+							}
+
+							// Copy requested block out of chunk buffer
+							int const offset_within_chunk =
+								(this_block_idx - chunk_start_idx) * DEFAULT_BLOCK_SIZE +
+								read_offset;
+							std::memcpy(buf, tls_chunk_buf.data() + offset_within_chunk,
+								std::size_t(r.length));
+						}
+					} else {
+						// < 75% missing: fall back to original single-block pread
+						auto const start_time = libtorrent::clock_type::now();
+						m_storages[idx]->read(buf, r.piece, r.start, r.length, error);
+						auto const read_time =
+							libtorrent::total_microseconds(libtorrent::clock_type::now() - start_time);
+
+						m_stats_counters.inc_stats_counter(libtorrent::counters::num_read_ops);
+						m_stats_counters.inc_stats_counter(libtorrent::counters::disk_read_time, read_time);
+						m_stats_counters.inc_stats_counter(libtorrent::counters::disk_job_time, read_time);
+
+						// Insert into cache (clean) for future reads
+						if (!error) {
+							m_cache.insert_read({idx, r.piece, block_offset}, buf, r.length);
+						}
+
+						m_stats_counters.inc_stats_counter(libtorrent::counters::num_blocks_read);
+					}
+				} else {
+					m_stats_counters.inc_stats_counter(libtorrent::counters::num_blocks_read);
+				}
 			}
 
 			// Post result back to main thread

--- a/raw_disk_io.cpp
+++ b/raw_disk_io.cpp
@@ -493,9 +493,16 @@ void raw_disk_io::async_clear_piece(libtorrent::storage_index_t storage,
 	libtorrent::piece_index_t index,
 	std::function<void(libtorrent::piece_index_t)> handler)
 {
-	post(m_ioc, [=] {
-		handler(index);
-	});
+	size_t thread_idx = get_thread_index(storage, index);
+	boost::asio::post((*m_io_thread_pools[thread_idx]),
+		[this, storage, index, handler = std::move(handler)]() mutable {
+			size_t removed = m_cache.clear_piece(storage, index);
+			spdlog::debug("[async_clear_piece] storage={} piece={} cleared {} entries",
+				static_cast<int>(storage), static_cast<int>(index), removed);
+			post(m_ioc, [index, h = std::move(handler)]() mutable {
+				h(index);
+			});
+		});
 }
 
 void raw_disk_io::update_stats_counters(libtorrent::counters &c) const

--- a/raw_disk_io.cpp
+++ b/raw_disk_io.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <string>
 #include <thread>
 #include <chrono>
@@ -66,6 +67,16 @@ raw_disk_io::raw_disk_io(libtorrent::io_context &ioc,
 	// NOTE: Don't use reserve() on m_io_thread_pools as thread_pool is not movable
 	size_t cache_entries = calculate_cache_entries(sett);
 	size_t entries_per_partition = cache_entries / m_num_io_threads;
+
+	// Derive prefetch chunk size from cache partition size
+	constexpr size_t PREFETCH_DIVISOR = 4;
+	constexpr size_t MIN_PREFETCH_BLOCKS = 16;
+	m_prefetch_blocks = std::max(MIN_PREFETCH_BLOCKS,
+		entries_per_partition / PREFETCH_DIVISOR);
+	spdlog::info("[raw_disk_io] Prefetch: {} blocks ({} KB) per chunk "
+				 "(derived from {} entries/partition / {})",
+		m_prefetch_blocks, m_prefetch_blocks * 16,
+		entries_per_partition, PREFETCH_DIVISOR);
 
 	spdlog::info("[raw_disk_io] Buffer pools initialized:");
 	spdlog::info("  Read pool:  {} MB ({} buffers)",

--- a/raw_disk_io.hpp
+++ b/raw_disk_io.hpp
@@ -39,6 +39,7 @@ private:
 	std::vector<std::unique_ptr<boost::asio::thread_pool>> m_io_thread_pools;
 
 	const size_t m_num_io_threads;	// Fixed at startup (from aio_threads setting)
+	size_t m_prefetch_blocks;  // Initial chunk size in blocks, clamped to piece at runtime
 
 	// Cache statistics reporting (temporary for debugging)
 	std::thread m_stats_thread;

--- a/unified_cache.cpp
+++ b/unified_cache.cpp
@@ -154,6 +154,33 @@ std::vector<torrent_location> cache_partition::collect_dirty_blocks_for_storage(
 	return dirty_blocks;
 }
 
+size_t cache_partition::clear_piece(libtorrent::storage_index_t storage,
+	libtorrent::piece_index_t piece)
+{
+	// Lock-free: called only from the owning worker thread (1:1 mapping).
+	size_t removed = 0;
+
+	auto it = m_entries.begin();
+	while (it != m_entries.end()) {
+		if (it->first.torrent == storage && it->first.piece == piece) {
+			// Remove from LRU list first
+			m_lru.erase(it->second.lru_iter);
+
+			// Update dirty counter if this entry was dirty
+			if (it->second.dirty) {
+				m_num_dirty--;
+			}
+
+			it = m_entries.erase(it);
+			++removed;
+		} else {
+			++it;
+		}
+	}
+
+	return removed;
+}
+
 size_t cache_partition::size() const
 {
 	return m_entries.size();
@@ -266,6 +293,17 @@ std::vector<torrent_location> unified_cache::collect_dirty_blocks(libtorrent::st
 	}
 
 	return all_dirty;
+}
+
+size_t unified_cache::clear_piece(libtorrent::storage_index_t storage,
+	libtorrent::piece_index_t piece)
+{
+	// Route to the owning partition via consistent hashing on (storage, piece).
+	// Use offset=0 as a representative location for hashing — get_partition_index
+	// hashes only storage + piece, not offset.
+	torrent_location representative(storage, piece, 0);
+	size_t partition_idx = get_partition_index(representative);
+	return m_partitions[partition_idx]->clear_piece(storage, piece);
 }
 
 size_t unified_cache::total_entries() const

--- a/unified_cache.hpp
+++ b/unified_cache.hpp
@@ -215,6 +215,15 @@ public:
 		return false;
 	}
 
+	// Existence probe — does NOT touch LRU or hit/miss stats.
+	// Use for cheap "is this block cached?" checks (e.g. prefetch chunk probing)
+	// where finding the block does not constitute a real read access.
+	// Lock-free: 1:1 thread:partition mapping ensures single-threaded access.
+	bool has(torrent_location const &loc) const
+	{
+		return m_entries.find(loc) != m_entries.end();
+	}
+
 	// Get two entries at once
 	// Similar to store_buffer::get2()
 	// Lock-free: 1:1 thread:partition mapping ensures single-threaded access
@@ -342,6 +351,14 @@ public:
 	{
 		size_t partition_idx = get_partition_index(loc);
 		return m_partitions[partition_idx]->get(loc, f);
+	}
+
+	// Existence probe — does NOT touch LRU or hit/miss stats.
+	// Forwards to the owning partition's cache_partition::has().
+	bool has(torrent_location const &loc) const
+	{
+		size_t partition_idx = get_partition_index(loc);
+		return m_partitions[partition_idx]->has(loc);
 	}
 
 	// Get two entries at once

--- a/unified_cache.hpp
+++ b/unified_cache.hpp
@@ -274,6 +274,9 @@ public:
 	// Collect dirty blocks for a specific storage only
 	std::vector<torrent_location> collect_dirty_blocks_for_storage(libtorrent::storage_index_t storage);
 
+	// Remove all entries belonging to (storage, piece). Lock-free: owner-thread only.
+	size_t clear_piece(libtorrent::storage_index_t storage, libtorrent::piece_index_t piece);
+
 	// Statistics
 	size_t size() const;
 	size_t dirty_count() const;
@@ -385,6 +388,10 @@ public:
 
 	// Collect all dirty blocks for a storage
 	std::vector<torrent_location> collect_dirty_blocks(libtorrent::storage_index_t storage);
+
+	// Remove all cached entries for (storage, piece). Forwards to the owning partition.
+	// Lock-free: must be called from the owning worker thread.
+	size_t clear_piece(libtorrent::storage_index_t storage, libtorrent::piece_index_t piece);
 
 	// Statistics
 	size_t total_entries() const;


### PR DESCRIPTION
## Summary

Implements `tmp/seeder_prefetch_spec.md` — adds chunk-based read prefetch to lift cache-miss seeder upload from ~340 MB/s toward the ~800 MB/s cache-hit ceiling, while preserving Phase 3.1's lock-free 1-thread-per-partition design.

## Root cause

`raw_disk_io::async_read` pins every block of a piece to a single worker thread via `get_thread_index(storage, piece)`. Each 16 KB block becomes one `pread` syscall at iodepth=1, capping at ~340 MB/s on the measured hardware. Kernel readahead can't help because requests look random (different pieces hash to different threads).

## Commits (in order)

- `e13765e` perf(partition_storage): hint kernel sequential access via posix_fadvise
- `ad6d5ac` feat(raw_disk_io): derive prefetch chunk size from cache and aio_threads
- `978cbb6` feat(unified_cache): add clear_piece for invalidating bad piece
- `b8b0299` feat(raw_disk_io): clear cached entries for failed pieces
- `57c3b7e` perf(raw_disk_io): warm cache from async_hash disk reads
- `f809ae8` perf(raw_disk_io): chunk-aligned read prefetch on cache miss

## Design (key invariants preserved)

- Lock-free: all prefetch operations happen on the owning worker thread; no new mutexes added to `unified_cache` or `buffer_pool`.
- No piece-boundary crossing: chunks are clamped within the current piece so all touched cache entries belong to the same partition.
- 75% miss threshold: only do a chunk pread when ≥75% of the chunk's blocks are absent from cache; otherwise fall through to the original single-block path.
- Bulk insert skips already-cached blocks to avoid LRU disruption and redundant allocation.
- `posix_fadvise(POSIX_FADV_SEQUENTIAL)` on partition fd at open.
- `m_prefetch_blocks = max(16, (cache_entries / aio_threads) / 4)` — derived once at construction; default settings yield 512 blocks (8 MB) per chunk.

## Test plan

- [ ] Build is clean (verified locally: `cmake --build build` succeeds).
- [ ] clang-format produces no diff on changed files (verified locally).
- [ ] Run a single-peer seeder→leecher transfer on cold cache; observe upload ≥ 800 MB/s (was ~340 MB/s).
- [ ] Verify cache hit rate climbs after the first few seconds.
- [ ] No new ASan/UBSan complaints if those builds are enabled.
- [ ] Confirm `[raw_disk_io] Prefetch: 512 blocks (8192 KB) per chunk ...` log line appears with default `--cache-size 32768 --aio-threads 16`.