### PR TITLE
perf(daemon): skip lazy hash verification when seeding from trusted source

### DIFF
--- a/daemon.cpp
+++ b/daemon.cpp
@@ -60,6 +60,14 @@ void ezio::add_torrent(std::string torrent_body, std::string save_path, bool see
 
 	if (seeding_mode) {
 		atp.flags |= libtorrent::torrent_flags::seed_mode;
+		// Pre-mark every piece as already verified so libtorrent skips the
+		// lazy async_hash that seed_mode normally fires on first peer
+		// request. Our seeder's source is the same raw image the torrent
+		// metadata was generated from (e.g. partclone -> torrent_create),
+		// so re-hashing it on every cold start only catches on-disk
+		// corruption we don't try to detect, and costs significant wall
+		// time (~48s on a 60 GiB torrent in 1-on-1 tests).
+		atp.verified_pieces.resize(atp.ti->num_pieces(), true);
 	}
 
 	if (sequential_download) {


### PR DESCRIPTION
## Summary

When ezio adds a torrent in seeding mode, fill `lt::add_torrent_params::verified_pieces` with all-true bits so libtorrent skips the lazy `async_hash` it normally fires on each piece's first peer request in seed mode.

## Background

libtorrent's `seed_mode` (`torrent_flags::seed_mode`) tells libtorrent "this client already has every piece on disk". For safety, libtorrent still hash-verifies each piece the first time a peer requests it — see `peer_connection.cpp:5298`:

```cpp
if (seed_mode && !t->verified_piece(r.piece) && !disable_hash_checks) {
    m_disk_thread.async_hash(...);   // re-read entire 16 MiB piece, recompute SHA1
    continue;
}
// only after async_hash completes do we proceed to async_read
```

For ezio's use case — `partclone` (or similar) generates the raw image and the torrent metadata in one step, and ezio seeds that same image — the source is trusted by construction. The lazy verify just re-reads + re-hashes the whole 60+ GiB image piece-by-piece as peers ask for them.

libtorrent provides a per-torrent escape hatch: `add_torrent_params::verified_pieces`. From its docstring (`add_torrent_params.hpp:326-329`):

> when in seed_mode, pieces with a set bit in this bitfield have been verified to be valid. Other pieces will be verified the first time a peer requests it.

We set every bit when seeding mode is on, so libtorrent treats every piece as already verified at session start. The lazy-verify branch in `peer_connection.cpp:5298` evaluates `verified_piece(P) == true` and is skipped. `async_hash` never fires on the seeder.

## Measured results

Distributed benchmark on the same setup as PR #135 (4 trusted VMs, 8 vCPU + 16 GiB each, ADATA SX8200 Pro NVMe, 25 GbE LAN), 60.6 GiB partclone torrent, `blkdiscard` + `drop_caches` between every run, fresh ezio processes (cold start, no seeder warmup), cache = 4 GiB, 3 runs per cell.

### 1-on-1 (1 seeder + 1 leecher)

| variant | r1 | r2 | r3 | mean | seeder hit | torrent_MiB/s |
|---|---:|---:|---:|---:|---:|---:|
| master baseline | 123s | 122s | 122s | **122s** | 50.0% | 509 |
| **this PR** | **77s** | **74s** | **76s** | **76s** | **93.8%** | **821** |
| warm-seeder reference (no async_hash) | – | – | – | 74s | 64.6%\* | 839 |

**1-on-1: 122s → 76s, -46s, -38% wall (+63% throughput).** Matches the warm-seeder reference, which is the architectural ceiling (leecher NVMe write + libtorrent peer protocol — no further async_hash to save).

\* warm-seeder hit rate is cumulative across cold iter1 + warm iter2, so it averages lower than the steady-state skiphash number.

### 1-to-3 (1 seeder + 3 leechers)

| variant | r1 | r2 | r3 | mean | seeder hit | torrent_MiB/s |
|---|---:|---:|---:|---:|---:|---:|
| master baseline | 171s | 171s | 181s | **174s** | 58.5% | 359 |
| **this PR** | **165s** | **166s** | **174s** | **168s** | **96.9%** | 370 |
| warm-seeder reference | – | – | – | 166s | 78.1%\* | 374 |

**1-to-3: 174s → 168s, -6s, -3.4% wall.** Modest wall-clock improvement, as expected — in 1-to-3 the async_hash work was already being parallelised with peer-to-peer transfers and other partition I/O, so removing it doesn't expose much speedup. **The real win on this topology is on the seeder CPU side: ~124s of software SHA1 work is gone**, freeing the seeder to handle more peers if the swarm grows.

### Why seeder hit rate goes from ~50% → ~94%

Without this PR, on cold seeder:
- async_hash fires once per piece on first peer request, doing 1024 cache lookups (all miss) + inserting 1024 entries
- The peer then issues 1024 async_reads against those now-warm blocks (all hit)
- ⇒ hit rate ≈ 1024 hits / (1024 misses + 1024 hits) = 50%

With this PR:
- async_hash never fires
- Each peer request goes straight to async_read
- The chunk-aligned prefetch (PR #135) reads 16 blocks per cache miss
- ⇒ 1 miss every 16 block requests = **15/16 = 93.75% hit rate** (exactly what we measured)

The 1-to-3 number (97%) is higher than 1-on-1 (94%) because three peers share the same chunk-warmed cache entries, so each chunk amortises across multiple peer requests instead of one.

### Variance

| cell | range | σ |
|---|---|---:|
| 1-on-1 skiphash | 74-77s | 1.5s |
| 1-to-3 skiphash | 165-174s | 5s |

Same variance order as baseline — no stability regression from skipping the hash.

## Scope

- Only takes effect when `seeding_mode=true` (the existing gRPC `AddTorrent.seeding_mode` field). Leecher path is **unchanged** — leechers still hash every downloaded piece against the torrent's expected SHA1.
- No gRPC schema change; existing clients keep working.
- Implicit policy change: "if you ask ezio to seed, you're saying the source is trustworthy". For Clonezilla Lite-Server / partclone-driven deployments this matches existing practice. A caller that wants defensive lazy verification of an externally-supplied seed image would now need a flag — can be added as a follow-up if anyone asks.

## Risks reviewed

- **What if the seeder's source disk is silently corrupted?** Without this PR, libtorrent would catch it on the first peer request and `state_changed` to `seed_mode` becomes `false`. With this PR, the corrupted data flows out to peers, where the leecher's SHA1 check will reject the piece and re-request from another peer (or, in 1-on-1, fail the torrent). For the targeted use case (raw image generated from the same torrent metadata), this scenario is not a concern in practice.
- **What about partial writes / disk hardware errors during the seeding session?** Out of scope — same situation as without this PR (libtorrent only verifies on first request anyway; subsequent corruption mid-session is never caught).

## Test plan

- [x] Build cleanly on tjjh89017/ezio CI
- [x] 1-on-1 cold seeder × 3: 76s mean (matches warm-seeder reference 74s; baseline was 122s)
- [x] 1-to-3 cold seeder × 3: 168s mean (baseline 174s, warm-seeder reference 166s)
- [x] Leecher cache hit rate stays ≥99% across all 6 runs (sanity that leecher behaviour didn't drift)
- [x] No async_hash counters incremented on seeder logs (verified — `num_blocks_hashed` never gets bumped on the seeder process)

Based on top of #135 (now merged into master).