### PR TITLE
refactor: io_context daemon event loop + session-wide slow-start upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ __pycache__/
 /.vscode/
 /build/
 /compile_commands.json
+
+# powerloop tracking notes
+/.powerloop/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_CXX_STANDARD 14)
 
 set(sources
 	main.cpp
+	app.cpp
 	config.cpp
 	daemon.cpp
 	buffer_pool.cpp

--- a/README.md
+++ b/README.md
@@ -131,13 +131,17 @@ find . -maxdepth 1 -name "*.cpp" -o -name "*.hpp" | grep -v "./tmp/" | xargs cla
 
 ```
 Allowed Options:
-  -h [ --help ]       show help
-  -F [ --file ]       read/write a regular file instead of a raw disk
-  -l [ --listen ] arg gRPC listen address:port (default 127.0.0.1:50051)
-  --cache-size arg    unified cache size in MB (default 512)
-  --aio-threads arg   threads for disk I/O and hashing (default 16)
-  -v [ --version ]    show version
+  -h [ --help ]            show help
+  -F [ --file ]            read/write a regular file instead of a raw disk
+  -l [ --listen ] arg      gRPC listen address:port (default 127.0.0.1:50051)
+  --cache-size arg         unified cache size in MB (default 512)
+  --aio-threads arg        threads for disk I/O and hashing (default 16)
+  --slow-start             enable session-wide slow-start upload ramp (default off)
+  --slow-start-period arg  slow-start step period in seconds (default 10)
+  -v [ --version ]         show version
 ```
+
+When `--slow-start` is enabled, the seeder caps its **session-wide** upload at 10 MB/s on launch and steps it up by 10 MB/s every `--slow-start-period` seconds until it reaches 100 MB/s, after which the limit is removed (unlimited). This eases a fleet of leechers into a deploy instead of slamming them with full bandwidth from the first second. The ramp is purely time-based and open-loop (it starts at daemon launch, not when peers connect).
 
 ### Generate gRPC stubs (once)
 

--- a/app.cpp
+++ b/app.cpp
@@ -15,7 +15,7 @@ lt::session_params app::make_session_params(const config &cfg)
 	lt::settings_pack p;
 	// setup alert mask
 	p.set_int(lt::settings_pack::alert_mask,
-		lt::alert_category::error | lt::alert_category::status);
+		lt::alert_category::error | lt::alert_category::status | lt::alert_category::peer);
 
 	// disable all encrypt to avoid bug https://github.com/arvidn/libtorrent/issues/6735#issuecomment-1036675263
 	p.set_int(lt::settings_pack::out_enc_policy, lt::settings_pack::pe_disabled);

--- a/app.cpp
+++ b/app.cpp
@@ -38,14 +38,16 @@ lt::session_params app::make_session_params(const config &cfg)
 	p.set_int(lt::settings_pack::send_buffer_watermark, 128 * 1024 * 1024);
 	p.set_int(lt::settings_pack::send_buffer_low_watermark, 32 * 1024 * 1024);
 
-	// Make the slow-start ramp actually throttle LAN peers. libtorrent defaults
-	// ignore_limits_on_local_network=true, which routes private-range IPs into the
-	// unthrottled local peer class and bypasses the global upload_rate_limit the
-	// ramp sets -- so without this the ramp is inert on a LAN, EZIO's only
-	// deployment target.
-	if (cfg.slow_start) {
-		p.set_bool(lt::settings_pack::ignore_limits_on_local_network, false);
-	}
+	// Keep the session-wide caps out of the way; the effective limits are enforced
+	// per-torrent (max_connections / max_uploads, set in add_torrent). A high
+	// connections_limit and an unlimited unchoke_slots_limit (-1) let the
+	// per-torrent max_uploads be the sole governor of how many peers the seeder
+	// unchokes. Peers are routed into the global peer class (see
+	// set_peer_class_filter in the app ctor) so the session-wide upload_rate_limit
+	// the slow-start ramp sets reaches LAN peers too -- libtorrent's default would
+	// otherwise exempt them via a local class.
+	p.set_int(lt::settings_pack::connections_limit, 1000);
+	p.set_int(lt::settings_pack::unchoke_slots_limit, -1);
 
 	// unified_cache size from config (default 512MB)
 	// Note: cache_size is deprecated but still used by raw_disk_io
@@ -64,6 +66,20 @@ lt::session_params app::make_session_params(const config &cfg)
 
 app::app(const config &cfg) : m_config(cfg), m_session(make_session_params(cfg)), m_daemon(m_session, m_config.slow_start, m_config.slow_start_period), m_service(m_daemon), m_log(m_daemon, m_daemon.get_io_context())
 {
+	// Route every peer -- including LAN/private addresses -- into the global peer
+	// class. By default libtorrent maps private-range IPs to a separate local
+	// peer class that ignores the session-wide upload_rate_limit (and the unchoke
+	// slot limits). Putting everyone in the global class makes the slow-start
+	// ramp's rate limit apply uniformly and lets the per-torrent max_uploads
+	// govern the unchoke count. This is the non-deprecated equivalent of
+	// ignore_limits_on_local_network=false.
+	lt::ip_filter pc_filter;
+	const std::uint32_t global_class =
+		1u << static_cast<std::uint32_t>(lt::session::global_peer_class_id);
+	pc_filter.add_rule(lt::make_address("0.0.0.0"), lt::make_address("255.255.255.255"), global_class);
+	pc_filter.add_rule(lt::make_address("::"),
+		lt::make_address("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"), global_class);
+	m_session.set_peer_class_filter(pc_filter);
 }
 
 int app::run()

--- a/app.cpp
+++ b/app.cpp
@@ -1,0 +1,73 @@
+#include "app.hpp"
+
+#include <iostream>
+
+#include "spdlog/spdlog.h"
+
+#include <libtorrent/libtorrent.hpp>
+
+#include "raw_disk_io.hpp"
+
+namespace ezio
+{
+
+// static
+lt::session_params app::make_session_params(const config &cfg)
+{
+	lt::settings_pack p;
+	// setup alert mask
+	p.set_int(lt::settings_pack::alert_mask,
+		lt::alert_category::error | lt::alert_category::status);
+
+	// disable all encrypt to avoid bug https://github.com/arvidn/libtorrent/issues/6735#issuecomment-1036675263
+	p.set_int(lt::settings_pack::out_enc_policy, lt::settings_pack::pe_disabled);
+	p.set_int(lt::settings_pack::in_enc_policy, lt::settings_pack::pe_disabled);
+
+	// disable uTP for better performance
+	p.set_bool(lt::settings_pack::enable_outgoing_utp, false);
+	p.set_bool(lt::settings_pack::enable_incoming_utp, false);
+	p.set_int(lt::settings_pack::mixed_mode_algorithm, lt::settings_pack::prefer_tcp);
+
+	// thread pool size from config (used for both I/O and hashing)
+	p.set_int(lt::settings_pack::aio_threads, cfg.aio_threads);
+	p.set_int(lt::settings_pack::hashing_threads, cfg.aio_threads);
+	spdlog::info("Thread pool: aio_threads={} (used for both I/O and hashing)", cfg.aio_threads);
+
+	// network buffer sizes
+	p.set_int(lt::settings_pack::suggest_mode, lt::settings_pack::suggest_read_cache);
+	p.set_int(lt::settings_pack::max_queued_disk_bytes, 128 * 1024 * 1024);
+	p.set_int(lt::settings_pack::send_not_sent_low_watermark, 524288);
+	p.set_int(lt::settings_pack::send_buffer_watermark, 128 * 1024 * 1024);
+	p.set_int(lt::settings_pack::send_buffer_low_watermark, 32 * 1024 * 1024);
+
+	// unified_cache size from config (default 512MB)
+	// Note: cache_size is deprecated but still used by raw_disk_io
+	// cache_size unit: number of 16KiB blocks
+	// Convert MB to number of 16KB blocks: (MB * 1024) / 16
+	int cache_blocks = (cfg.cache_size_mb * 1024) / 16;
+	p.set_int(lt::settings_pack::cache_size, cache_blocks);
+	spdlog::info("Cache size: {} MB ({} blocks)", cfg.cache_size_mb, cache_blocks);
+
+	lt::session_params ses_params(p);
+	if (!cfg.file_flag) {
+		ses_params.disk_io_constructor = raw_disk_io_constructor;
+	}
+	return ses_params;
+}
+
+app::app(const config &cfg) : m_config(cfg), m_session(make_session_params(cfg)), m_daemon(m_session), m_service(m_daemon), m_log(m_daemon, m_daemon.get_io_context())
+{
+}
+
+int app::run()
+{
+	m_service.start(m_config.listen_address);
+	m_log.start();
+	std::cout << "Server listening on " << m_config.listen_address << std::endl;
+	m_daemon.run();
+	std::cout << "shutdown in main" << std::endl;
+	m_service.stop();
+	return 0;
+}
+
+}  // namespace ezio

--- a/app.cpp
+++ b/app.cpp
@@ -55,7 +55,7 @@ lt::session_params app::make_session_params(const config &cfg)
 	return ses_params;
 }
 
-app::app(const config &cfg) : m_config(cfg), m_session(make_session_params(cfg)), m_daemon(m_session), m_service(m_daemon), m_log(m_daemon, m_daemon.get_io_context())
+app::app(const config &cfg) : m_config(cfg), m_session(make_session_params(cfg)), m_daemon(m_session, m_config.slow_start, m_config.slow_start_period), m_service(m_daemon), m_log(m_daemon, m_daemon.get_io_context())
 {
 }
 

--- a/app.cpp
+++ b/app.cpp
@@ -38,6 +38,15 @@ lt::session_params app::make_session_params(const config &cfg)
 	p.set_int(lt::settings_pack::send_buffer_watermark, 128 * 1024 * 1024);
 	p.set_int(lt::settings_pack::send_buffer_low_watermark, 32 * 1024 * 1024);
 
+	// Make the slow-start ramp actually throttle LAN peers. libtorrent defaults
+	// ignore_limits_on_local_network=true, which routes private-range IPs into the
+	// unthrottled local peer class and bypasses the global upload_rate_limit the
+	// ramp sets -- so without this the ramp is inert on a LAN, EZIO's only
+	// deployment target.
+	if (cfg.slow_start) {
+		p.set_bool(lt::settings_pack::ignore_limits_on_local_network, false);
+	}
+
 	// unified_cache size from config (default 512MB)
 	// Note: cache_size is deprecated but still used by raw_disk_io
 	// cache_size unit: number of 16KiB blocks

--- a/app.cpp
+++ b/app.cpp
@@ -1,7 +1,5 @@
 #include "app.hpp"
 
-#include <iostream>
-
 #include "spdlog/spdlog.h"
 
 #include <libtorrent/libtorrent.hpp>
@@ -63,9 +61,9 @@ int app::run()
 {
 	m_service.start(m_config.listen_address);
 	m_log.start();
-	std::cout << "Server listening on " << m_config.listen_address << std::endl;
+	spdlog::info("Server listening on {}", m_config.listen_address);
 	m_daemon.run();
-	std::cout << "shutdown in main" << std::endl;
+	spdlog::info("shutdown in main");
 	m_service.stop();
 	return 0;
 }

--- a/app.hpp
+++ b/app.hpp
@@ -1,0 +1,34 @@
+#ifndef __APP_HPP__
+#define __APP_HPP__
+
+#include <boost/core/noncopyable.hpp>
+#include <libtorrent/libtorrent.hpp>
+
+#include "config.hpp"
+#include "daemon.hpp"
+#include "log.hpp"
+#include "service.hpp"
+
+namespace ezio
+{
+
+class app : boost::noncopyable
+{
+public:
+	explicit app(const config &cfg);
+
+	int run();
+
+private:
+	static lt::session_params make_session_params(const config &cfg);
+
+	config m_config;
+	lt::session m_session;
+	ezio m_daemon;
+	gRPCService m_service;
+	log m_log;
+};
+
+}  // namespace ezio
+
+#endif

--- a/config.cpp
+++ b/config.cpp
@@ -14,6 +14,8 @@ void config::parse_from_argv(int argc, char **argv)
 		("listen,l", bpo::value<std::string>(&listen_address), "gRPC service listen address and port, default is 127.0.0.1:50051")
 		("cache-size", bpo::value<int>(&cache_size_mb)->default_value(512), "unified cache size in MB, default is 512")
 		("aio-threads", bpo::value<int>(&aio_threads)->default_value(16), "number of threads for disk I/O and hashing, default is 16")
+		("slow-start", bpo::bool_switch(&slow_start)->default_value(false), "enable session-wide slow-start upload ramp (default off)")
+		("slow-start-period", bpo::value<int>(&slow_start_period)->default_value(10), "slow-start step period in seconds (default 10)")
 		("version,v", "show version")
 	;
 	// clang-format on

--- a/config.hpp
+++ b/config.hpp
@@ -25,6 +25,10 @@ public:
 	int cache_size_mb = 512;  // default 512MB
 	// thread pool size (used for both I/O and hashing)
 	int aio_threads = 16;  // default 16 threads for disk I/O
+	// enable session-wide slow-start upload ramp
+	bool slow_start = false;
+	// slow-start step period in seconds
+	int slow_start_period = 10;	 // default 10 seconds
 };
 
 }  // namespace ezio

--- a/daemon.cpp
+++ b/daemon.cpp
@@ -4,6 +4,7 @@
 #include <spdlog/spdlog.h>
 #include <vector>
 #include <boost/asio/error.hpp>
+#include <boost/asio/post.hpp>
 #include "daemon.hpp"
 #include "version.hpp"
 
@@ -29,6 +30,13 @@ void ezio::run()
 		if (ec == boost::asio::error::operation_aborted) {
 			return;
 		}
+		// Re-arm before posting shutdown so a second SIGINT/SIGTERM is not
+		// silently swallowed while the shutdown lambda is still pending.
+		m_signals.async_wait([this](const boost::system::error_code &ec2, int) {
+			if (ec2 != boost::asio::error::operation_aborted) {
+				request_shutdown();
+			}
+		});
 		request_shutdown();
 	});
 
@@ -51,6 +59,9 @@ void ezio::arm_reannounce()
 
 void ezio::request_shutdown()
 {
+	// Set eagerly (before the post) so get_shutdown() readers (log, gRPC)
+	// see the flag immediately, even though the io_context is still running.
+	// Safe cross-thread: m_shutdown is std::atomic_bool.
 	m_shutdown = true;
 	boost::asio::post(m_ioc, [this] {
 		m_reannounce_timer.cancel();

--- a/daemon.cpp
+++ b/daemon.cpp
@@ -8,14 +8,25 @@
 #include "daemon.hpp"
 #include "version.hpp"
 
+namespace
+{
+constexpr int SLOW_START_INITIAL = 10 * 1024 * 1024;  // 10 MB/s
+constexpr int SLOW_START_STEP = 10 * 1024 * 1024;  // +10 MB/s per period
+constexpr int SLOW_START_CAP = 100 * 1024 * 1024;  // 100 MB/s -> beyond = unlimited
+}  // namespace
+
 namespace ezio
 {
-ezio::ezio(lt::session &session) :
+ezio::ezio(lt::session &session, bool slow_start, int slow_start_period) :
 	m_session(session),
 	m_shutdown(false),
 	m_work_guard(boost::asio::make_work_guard(m_ioc)),
 	m_reannounce_timer(m_ioc),
-	m_signals(m_ioc, SIGINT, SIGTERM)
+	m_signals(m_ioc, SIGINT, SIGTERM),
+	m_slow_start_timer(m_ioc),
+	m_slow_start(slow_start),
+	m_slow_start_period(slow_start_period > 0 ? slow_start_period : 10),
+	m_slow_start_limit(0)
 {
 }
 
@@ -41,7 +52,45 @@ void ezio::run()
 	});
 
 	arm_reannounce();
+
+	if (m_slow_start) {
+		m_slow_start_limit = SLOW_START_INITIAL;
+		apply_session_upload_limit(m_slow_start_limit);
+		schedule_slow_start_step();
+	}
+
 	m_ioc.run();
+}
+
+void ezio::apply_session_upload_limit(int bytes_per_second)
+{
+	lt::settings_pack p;
+	p.set_int(lt::settings_pack::upload_rate_limit, bytes_per_second);
+	m_session.apply_settings(p);
+	if (bytes_per_second == 0) {
+		spdlog::debug("slow-start: upload rate limit cleared (unlimited)");
+	} else {
+		spdlog::info("slow-start: upload limit set to {} MB/s", bytes_per_second / (1024 * 1024));
+	}
+}
+
+void ezio::schedule_slow_start_step()
+{
+	m_slow_start_timer.expires_after(std::chrono::seconds(m_slow_start_period));
+	m_slow_start_timer.async_wait([this](const boost::system::error_code &ec) {
+		if (ec == boost::asio::error::operation_aborted) {
+			return;
+		}
+		int next = m_slow_start_limit + SLOW_START_STEP;
+		if (next >= SLOW_START_CAP) {
+			apply_session_upload_limit(0);
+			spdlog::info("slow-start complete: upload limit removed");
+			return;
+		}
+		m_slow_start_limit = next;
+		apply_session_upload_limit(m_slow_start_limit);
+		schedule_slow_start_step();
+	});
 }
 
 void ezio::arm_reannounce()
@@ -65,6 +114,7 @@ void ezio::request_shutdown()
 	m_shutdown = true;
 	boost::asio::post(m_ioc, [this] {
 		m_reannounce_timer.cancel();
+		m_slow_start_timer.cancel();
 		m_signals.cancel();
 		for (auto &hook : m_shutdown_hooks) {
 			hook();

--- a/daemon.cpp
+++ b/daemon.cpp
@@ -1,39 +1,75 @@
 #include <sstream>
-#include <thread>
 #include <chrono>
 #include <stdexcept>
 #include <spdlog/spdlog.h>
 #include <vector>
+#include <boost/asio/error.hpp>
 #include "daemon.hpp"
 #include "version.hpp"
 
 namespace ezio
 {
 ezio::ezio(lt::session &session) :
-	m_session(session), m_shutdown(false)
+	m_session(session),
+	m_shutdown(false),
+	m_work_guard(boost::asio::make_work_guard(m_ioc)),
+	m_reannounce_timer(m_ioc),
+	m_signals(m_ioc, SIGINT, SIGTERM)
 {
 }
 
 void ezio::stop()
 {
-	m_shutdown = true;
+	request_shutdown();
 }
 
-void ezio::wait(int interval_second)
+void ezio::run()
 {
-	constexpr int reannounce_interval = 60;
-	int elapsed = 0;
-
-	while (!m_shutdown) {
-		std::this_thread::sleep_for(std::chrono::seconds(interval_second));
-		elapsed += interval_second;
-
-		if (elapsed >= reannounce_interval) {
-			force_reannounce_all();
-			spdlog::debug("periodic force reannounce done");
-			elapsed = 0;
+	m_signals.async_wait([this](const boost::system::error_code &ec, int /*signum*/) {
+		if (ec == boost::asio::error::operation_aborted) {
+			return;
 		}
-	}
+		request_shutdown();
+	});
+
+	arm_reannounce();
+	m_ioc.run();
+}
+
+void ezio::arm_reannounce()
+{
+	m_reannounce_timer.expires_after(std::chrono::seconds(60));
+	m_reannounce_timer.async_wait([this](const boost::system::error_code &ec) {
+		if (ec == boost::asio::error::operation_aborted) {
+			return;
+		}
+		force_reannounce_all();
+		spdlog::debug("periodic force reannounce done");
+		arm_reannounce();
+	});
+}
+
+void ezio::request_shutdown()
+{
+	m_shutdown = true;
+	boost::asio::post(m_ioc, [this] {
+		m_reannounce_timer.cancel();
+		m_signals.cancel();
+		for (auto &hook : m_shutdown_hooks) {
+			hook();
+		}
+		m_work_guard.reset();
+	});
+}
+
+lt::io_context &ezio::get_io_context()
+{
+	return m_ioc;
+}
+
+void ezio::register_shutdown_hook(std::function<void()> hook)
+{
+	m_shutdown_hooks.push_back(std::move(hook));
 }
 
 void ezio::add_torrent(std::string torrent_body, std::string save_path, bool seeding_mode = false, int max_uploads = 3, int max_connections = 5, bool sequential_download = false)

--- a/daemon.cpp
+++ b/daemon.cpp
@@ -68,7 +68,7 @@ void ezio::apply_session_upload_limit(int bytes_per_second)
 	p.set_int(lt::settings_pack::upload_rate_limit, bytes_per_second);
 	m_session.apply_settings(p);
 	if (bytes_per_second == 0) {
-		spdlog::debug("slow-start: upload rate limit cleared (unlimited)");
+		spdlog::info("slow-start: upload rate limit cleared (unlimited)");
 	} else {
 		spdlog::info("slow-start: upload limit set to {} MB/s", bytes_per_second / (1024 * 1024));
 	}

--- a/daemon.hpp
+++ b/daemon.hpp
@@ -41,7 +41,7 @@ struct torrent_status {
 class ezio : boost::noncopyable
 {
 public:
-	ezio(lt::session &);
+	ezio(lt::session &session, bool slow_start = false, int slow_start_period = 10);
 	~ezio() = default;
 
 	void stop();
@@ -61,6 +61,8 @@ public:
 
 private:
 	void arm_reannounce();
+	void apply_session_upload_limit(int bytes_per_second);
+	void schedule_slow_start_step();
 
 	lt::session &m_session;
 	std::atomic_bool m_shutdown;
@@ -68,7 +70,11 @@ private:
 	boost::asio::executor_work_guard<lt::io_context::executor_type> m_work_guard;
 	boost::asio::steady_timer m_reannounce_timer;
 	boost::asio::signal_set m_signals;
+	boost::asio::steady_timer m_slow_start_timer;
 	std::vector<std::function<void()>> m_shutdown_hooks;
+	bool m_slow_start;
+	int m_slow_start_period;
+	int m_slow_start_limit;
 };
 
 }  // namespace ezio

--- a/daemon.hpp
+++ b/daemon.hpp
@@ -2,10 +2,17 @@
 #define __DAEMON_HPP__
 
 #include <atomic>
+#include <csignal>
+#include <functional>
 #include <string>
 #include <vector>
-#include <libtorrent/libtorrent.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <boost/core/noncopyable.hpp>
+#include <libtorrent/libtorrent.hpp>
 
 namespace ezio
 {
@@ -39,7 +46,8 @@ public:
 	~ezio() = default;
 
 	void stop();
-	void wait(int interval_second);
+	void run();
+	void request_shutdown();
 	void add_torrent(std::string torrent_body, std::string save_path, bool seeding_mode, int max_uploads, int max_connections, bool sequential_download);
 	std::map<std::string, torrent_status> get_torrent_status(std::vector<std::string> hashes);
 	void pause_torrent(std::string hash);
@@ -49,11 +57,19 @@ public:
 	void set_alert_notify(std::function<void()> const &callback);
 	void force_reannounce_all();
 	std::string get_version();
+	lt::io_context &get_io_context();
+	void register_shutdown_hook(std::function<void()> hook);
 
 private:
-	lt::session &m_session;
+	void arm_reannounce();
 
+	lt::session &m_session;
 	std::atomic_bool m_shutdown;
+	lt::io_context m_ioc;
+	boost::asio::executor_work_guard<lt::io_context::executor_type> m_work_guard;
+	boost::asio::steady_timer m_reannounce_timer;
+	boost::asio::signal_set m_signals;
+	std::vector<std::function<void()>> m_shutdown_hooks;
 };
 
 }  // namespace ezio

--- a/daemon.hpp
+++ b/daemon.hpp
@@ -8,7 +8,6 @@
 #include <vector>
 #include <boost/asio/executor_work_guard.hpp>
 #include <boost/asio/io_context.hpp>
-#include <boost/asio/post.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/core/noncopyable.hpp>

--- a/docs/plan/backlog/SLOW_START_PEER_CLASS_VALIDATION.md
+++ b/docs/plan/backlog/SLOW_START_PEER_CLASS_VALIDATION.md
@@ -1,0 +1,99 @@
+# Slow-Start Peer-Class Routing + Seed-Choker Validation (2026-05-30)
+
+Branch `refactor/daemon-event-loop` (PR #141). Validates the "Design B" change
+(`app.cpp`, commit e3049af): route every peer into libtorrent's **global** peer
+class via the non-deprecated `set_peer_class_filter()`, raise
+`connections_limit` to 1000 and set `unchoke_slots_limit = -1`, so the
+session-wide `upload_rate_limit` (used by the slow-start ramp) throttles LAN
+peers and the per-torrent `max_connections`/`max_uploads` are the sole governors
+of fan-out.
+
+Cluster: 1 seeder (172.30.0.123) + 3 leechers (.124/.125/.126), Debian sid VMs
+on pve-x99, SX8200 Pro NVMe, 60.6 GiB partclone torrent, `blkdiscard` between
+runs, `SPDLOG_LEVEL=debug`. Binary rebuilt on the seeder (cluster boost 1.83 vs
+dev box 1.90) and distributed (md5-verified).
+
+## Why Design B (background)
+
+libtorrent's default routes private-range IPs (10/8, 172.16-31, 192.168/16,
+link-local, loopback) to a **local peer class** that is exempt from the global
+`upload_rate_limit` AND the unchoke-slot limits (`ignore_unchoke_slots=true`).
+On a LAN -- EZIO's target -- that made the slow-start ramp inert. The first fix
+used the deprecated `ignore_limits_on_local_network=false`; Design B replaces it
+with `set_peer_class_filter()` (the non-deprecated path qBittorrent also uses),
+which works for mixed LAN/WAN too.
+
+Key mechanism confirmed in libtorrent source:
+- `ignore_unchoke_slots` peers bypass both `unchoke_slots_limit` and per-torrent
+  `max_uploads` (`peer_connection.cpp:1854` immediate unchoke; not counted in
+  `num_peers_up_unchoked`). Global-class peers go through
+  `torrent::unchoke_peer()` which enforces `max_uploads`
+  (`torrent.cpp:6052`). => only the global class makes `max_uploads` govern
+  fan-out.
+- `unchoke_slots_limit < 0` => `INT_MAX` (`choker.cpp:222`), so `-1` lets
+  `max_uploads` be the sole cap.
+
+## Results
+
+### (1) Slow-start throttle -- PASS
+
+`--slow-start --slow-start-period 10` on the seeder. Seeder upload tracked each
+ramp step precisely, then jumped to full speed when the limit was removed:
+
+```
+limit 10 -> U  4.8     limit 60 -> U 56-61
+limit 20 -> U 13-18    limit 70 -> U 62-71
+limit 30 -> U 18-24    limit 80 -> U 71-76
+limit 40 -> U 24-36    limit 90 -> U 82-86
+limit 50 -> U 40-54    cleared  -> U 534 -> 780  (immediately)
+```
+
+Confirms the rate limit reaches LAN peers via the all-global filter -- same
+effect as the old deprecated flag, no deprecated API.
+
+### (2) Throughput regression -- NONE
+
+All runs are round_robin + max_uploads=2 (note: `ezio_add_torrent.py -u`
+defaults to 2, so every prior test was already max_uploads=2; the seed choker
+was always engaged with 3 leechers > 2 slots).
+
+| Run | elapsed | per-leecher throughput |
+|-----|---------|------------------------|
+| old model (pre-Design-B) baseline | 225.8 s | 274.9 MiB/s |
+| Design B baseline                 | 235.6 s | 263.4 MiB/s |
+| Design B (algo-rr)                | 225.8 s | 274.9 MiB/s |
+
+Design B overlaps the old model exactly (algo-rr == old baseline to the
+decimal). The ~10 s spread is run-to-run variance. No regression.
+
+Slow-start run under Design B: 305.6 s / 203 MiB/s -- the ~70 s over baseline is
+the deliberate ramp cost, not a defect.
+
+### (3) Seed choking algorithm -- keep `round_robin` (default)
+
+Forced contention with `max_uploads=2` (seeder must pick 2 of 3 leechers).
+Selected via a temporary `EZIO_SEED_CHOKER` env knob (since reverted -- not
+shipped; conclusion is to keep the default).
+
+| seed_choking_algorithm | elapsed | per-leecher throughput | distribution |
+|------------------------|---------|------------------------|--------------|
+| **round_robin** (default) | **225.8 s** | **274.9 MiB/s** | all 3 ~225.7 s |
+| fastest_upload            | 245.8 s | 252.5 MiB/s | all 3 ~245.8 s |
+
+`round_robin` ~9% faster. Both spread evenly (leecher<->leecher reseed keeps the
+choked node level). Matches theory: on a homogeneous LAN `fastest_upload`'s
+"stick to the fastest peer" gives no edge, while `round_robin`'s diverse-piece
+injection gives the mesh more to trade. `anti_leech` not tested (free-rider
+oriented, irrelevant to a cooperative fleet).
+
+Caveat: single run per arm; the 20 s gap is ~2x the observed variance --
+directionally clear and theory-consistent, not statistically proven.
+
+## Decisions
+
+- Ship Design B (committed e3049af). Slow-start throttle works without any
+  deprecated API; no throughput regression.
+- Keep `seed_choking_algorithm = round_robin` (libtorrent default) -- do not set
+  `fastest_upload`.
+- The `EZIO_SEED_CHOKER` env knob and `tests/distrib_test/config.algo.sh` were
+  benchmark-only and reverted/left in the working tree, not committed.

--- a/log.cpp
+++ b/log.cpp
@@ -1,50 +1,47 @@
-#include <spdlog/spdlog.h>
+#include <chrono>
 #include <vector>
+#include <boost/asio/post.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <spdlog/spdlog.h>
 #include <libtorrent/libtorrent.hpp>
 #include "log.hpp"
 
 namespace ezio
 {
-log::log(ezio &daemon) :
-	m_daemon(daemon)
+log::log(ezio &daemon, lt::io_context &ioc) :
+	m_daemon(daemon),
+	m_ioc(ioc),
+	m_speed_timer(ioc)
 {
-	m_speed = std::thread(&log::report_speed, this);
-	m_alert = std::thread(&log::report_alert, this);
+}
 
-	// Setup alert notification callback
-	m_daemon.set_alert_notify([this]() {
-		// This callback is called from libtorrent internal thread
-		// MUST be fast, MUST NOT block, MUST NOT call pop_alerts()
-		{
-			std::lock_guard<std::mutex> lock(m_alert_mutex);
-			m_alert_ready = true;
-		}
-		m_alert_cv.notify_one();
+void log::start()
+{
+	schedule_speed_report();
+
+	m_daemon.set_alert_notify([this] {
+		boost::asio::post(m_ioc, [this] {
+			process_alerts();
+		});
+	});
+
+	m_daemon.register_shutdown_hook([this] {
+		shutdown();
 	});
 }
 
-log::~log()
+void log::schedule_speed_report()
 {
-	join();
-}
-
-void log::join()
-{
-	m_speed.join();
-	m_alert.join();
-}
-
-void log::report_speed()
-{
-	spdlog::info("start speed report thread");
-	while (!m_daemon.get_shutdown()) {
-		std::this_thread::sleep_for(std::chrono::seconds(5));
+	m_speed_timer.expires_after(std::chrono::seconds(5));
+	m_speed_timer.async_wait([this](boost::system::error_code ec) {
+		if (ec == boost::asio::error::operation_aborted) {
+			return;
+		}
 
 		std::vector<std::string> hashes;
 		auto result = m_daemon.get_torrent_status(hashes);
 
 		for (const auto &iter : result) {
-			const auto &hash = iter.first;
 			const auto &t_stat = iter.second;
 
 			spdlog::info("[{}][{}%][D: {:.2f}MB/s][U: {:.2f}MB/s][{}{}][A: {}][F: {}][S: {}]",
@@ -58,42 +55,25 @@ void log::report_speed()
 				t_stat.finished_time,
 				t_stat.seeding_time);
 		}
+
+		schedule_speed_report();
+	});
+}
+
+void log::process_alerts()
+{
+	std::vector<libtorrent::alert *> alerts;
+	m_daemon.pop_alerts(&alerts);
+
+	for (auto a : alerts) {
+		spdlog::info("lt alert: {} {}", a->what(), a->message());
 	}
 }
 
-void log::report_alert()
+void log::shutdown()
 {
-	spdlog::info("start alert report thread");
-
-	while (!m_daemon.get_shutdown()) {
-		// Wait for alert notification (with 1-second timeout for shutdown check)
-		std::unique_lock<std::mutex> lock(m_alert_mutex);
-		m_alert_cv.wait_for(lock, std::chrono::seconds(1), [this]() {
-			return m_alert_ready || m_daemon.get_shutdown();
-		});
-
-		if (m_daemon.get_shutdown()) {
-			break;
-		}
-
-		if (!m_alert_ready) {
-			// Timeout - check shutdown and continue
-			continue;
-		}
-
-		m_alert_ready = false;
-		lock.unlock();
-
-		// Now pop and process alerts (outside of lock!)
-		std::vector<libtorrent::alert *> alerts;
-		m_daemon.pop_alerts(&alerts);
-
-		for (auto a : alerts) {
-			spdlog::info("lt alert: {} {}", a->what(), a->message());
-		}
-	}
-
-	spdlog::info("alert report thread exiting");
+	m_speed_timer.cancel();
+	m_daemon.set_alert_notify({});
 }
 
 }  // namespace ezio

--- a/log.hpp
+++ b/log.hpp
@@ -1,9 +1,8 @@
 #ifndef __LOG_HPP__
 #define __LOG_HPP__
 
-#include <thread>
-#include <mutex>
-#include <condition_variable>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include "daemon.hpp"
 
 namespace ezio
@@ -11,25 +10,18 @@ namespace ezio
 class log
 {
 public:
-	log(ezio &daemon);
-	~log();
+	log(ezio &daemon, lt::io_context &ioc);
 
-	void join();
-
-	// worker function
-	void report_speed();
-	void report_alert();
+	void start();
 
 private:
-	std::thread m_speed;
-	std::thread m_alert;
+	void schedule_speed_report();
+	void process_alerts();
+	void shutdown();
 
 	ezio &m_daemon;
-
-	// Alert notification synchronization
-	std::mutex m_alert_mutex;
-	std::condition_variable m_alert_cv;
-	bool m_alert_ready = false;
+	lt::io_context &m_ioc;
+	boost::asio::steady_timer m_speed_timer;
 };
 
 }  // namespace ezio

--- a/main.cpp
+++ b/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char **argv)
 	ezio::log log(daemon);
 
 	std::cout << "Server listening on " << current_config.listen_address << std::endl;
-	daemon.wait(10);
+	daemon.run();
 	std::cout << "shutdown in main" << std::endl;
 
 	log.join();

--- a/main.cpp
+++ b/main.cpp
@@ -1,88 +1,20 @@
-#include <memory>
 #include <iostream>
-#include <thread>
-#include <chrono>
-#include <getopt.h>
-#include <stddef.h>
+
 #include "spdlog/cfg/env.h"
-#include "spdlog/spdlog.h"
 
-#include <libtorrent/libtorrent.hpp>
-
-#include "daemon.hpp"
-#include "service.hpp"
+#include "app.hpp"
 #include "config.hpp"
-#include "raw_disk_io.hpp"
-#include "log.hpp"
 #include "version.hpp"
 
 int main(int argc, char **argv)
 {
 	spdlog::cfg::load_env_levels();
 
-	ezio::config current_config;
-	current_config.parse_from_argv(argc, argv);
+	ezio::config cfg;
+	cfg.parse_from_argv(argc, argv);
 
 	std::cout << "ezio " << EZIO_VERSION << std::endl;
 
-	lt::settings_pack p;
-	// setup alert mask
-	p.set_int(lt::settings_pack::alert_mask,
-		lt::alert_category::error | lt::alert_category::status);
-
-	// disable all encrypt to avoid bug https://github.com/arvidn/libtorrent/issues/6735#issuecomment-1036675263
-	p.set_int(lt::settings_pack::out_enc_policy, lt::settings_pack::pe_disabled);
-	p.set_int(lt::settings_pack::in_enc_policy, lt::settings_pack::pe_disabled);
-
-	// disable uTP for better performance
-	p.set_bool(lt::settings_pack::enable_outgoing_utp, false);
-	p.set_bool(lt::settings_pack::enable_incoming_utp, false);
-	p.set_int(lt::settings_pack::mixed_mode_algorithm, lt::settings_pack::prefer_tcp);
-
-	//p.set_int(lt::settings_pack::alert_mask, lt::alert_category::peer | lt::alert_category::status);
-
-	// thread pool size from config (used for both I/O and hashing)
-	p.set_int(lt::settings_pack::aio_threads, current_config.aio_threads);
-	p.set_int(lt::settings_pack::hashing_threads, current_config.aio_threads);
-	spdlog::info("Thread pool: aio_threads={} (used for both I/O and hashing)",
-		current_config.aio_threads);
-
-	// network buffer sizes
-	p.set_int(lt::settings_pack::suggest_mode, lt::settings_pack::suggest_read_cache);
-	p.set_int(lt::settings_pack::max_queued_disk_bytes, 128 * 1024 * 1024);
-	p.set_int(lt::settings_pack::send_not_sent_low_watermark, 524288);
-	p.set_int(lt::settings_pack::send_buffer_watermark, 128 * 1024 * 1024);
-	p.set_int(lt::settings_pack::send_buffer_low_watermark, 32 * 1024 * 1024);
-
-	// unified_cache size from config (default 512MB)
-	// Note: cache_size is deprecated but still used by raw_disk_io
-	// cache_size unit: number of 16KiB blocks
-	// Convert MB to number of 16KB blocks: (MB * 1024) / 16
-	int cache_blocks = (current_config.cache_size_mb * 1024) / 16;
-	p.set_int(lt::settings_pack::cache_size, cache_blocks);
-	spdlog::info("Cache size: {} MB ({} blocks)", current_config.cache_size_mb, cache_blocks);
-
-	lt::session_params ses_params(p);
-	if (!current_config.file_flag) {
-		ses_params.disk_io_constructor = ezio::raw_disk_io_constructor;
-	}
-
-	// create session and inject to daemon.
-	lt::session session(ses_params);
-	ezio::ezio daemon(session);
-
-	ezio::gRPCService service(daemon);
-	service.start(current_config.listen_address);
-
-	// start log
-	ezio::log log(daemon, daemon.get_io_context());
-	log.start();
-
-	std::cout << "Server listening on " << current_config.listen_address << std::endl;
-	daemon.run();
-	std::cout << "shutdown in main" << std::endl;
-
-	service.stop();
-
-	return 0;
+	ezio::app app(cfg);
+	return app.run();
 }

--- a/main.cpp
+++ b/main.cpp
@@ -75,13 +75,13 @@ int main(int argc, char **argv)
 	service.start(current_config.listen_address);
 
 	// start log
-	ezio::log log(daemon);
+	ezio::log log(daemon, daemon.get_io_context());
+	log.start();
 
 	std::cout << "Server listening on " << current_config.listen_address << std::endl;
 	daemon.run();
 	std::cout << "shutdown in main" << std::endl;
 
-	log.join();
 	service.stop();
 
 	return 0;


### PR DESCRIPTION
## Summary

Refactors the EZIO daemon control loop from a blocking sleep loop to a single boost::asio `io_context` event loop, folds the previously thread-based `log` onto that loop, extracts a composition root, and adds a session-wide slow-start upload ramp.

## Changes

- **daemon -> io_context event loop** (`9e89fb2`, `eec1423`): `wait(int)` replaced by `run()` which blocks on `m_ioc.run()`. Periodic 60s reannounce is now a self-rescheduling `boost::asio::steady_timer`. An `executor_work_guard` keeps `run()` alive while idle.
- **Graceful shutdown**: `request_shutdown()` posts onto `m_ioc`, cancels every pending async op (timers + signal_set), runs registered shutdown hooks, then resets the work guard so `run()` drains and returns -- no abrupt `io_context::stop()`. Async handlers treat `operation_aborted` as a normal cancel.
- **Signals**: SIGINT/SIGTERM handled via `boost::asio::signal_set` -> `request_shutdown()` (re-armed so a second Ctrl-C is not dropped).
- **log de-threaded** (`8175ebc`): speed report is a 5s `steady_timer` on the daemon's io_context; alert handling is event-driven (the libtorrent notify callback only posts `process_alerts` onto the loop). Removed the two `std::thread`s, the mutex, the condition_variable, `m_alert_ready`, and `join()`. `log` registers a shutdown hook to cancel its timer + detach the notify.
- **app composition root** (`414eb3b`, `8fffed0`): new `ezio::app` owns config/session/daemon/service/log and exposes `run()`; `settings_pack` construction moved verbatim into `make_session_params(config)`; `main.cpp` is now thin and calls `app.run()`.
- **Slow-start upload ramp** (`8c53611`, `0ebaa9d`): new daemon CLI options `--slow-start` (bool, default false) and `--slow-start-period` (seconds, default 10). When enabled, at `run()` startup the session-wide upload rate limit starts at 10 MB/s and a `steady_timer` steps it +10 MB/s each period until it would reach 100 MB/s, then sets it to 0 (unlimited) and stops. Applied via `settings_pack::upload_rate_limit` + `session::apply_settings`; the ramp timer is cancelled on graceful shutdown. Session-wide (not per-torrent), CLI-driven (no gRPC/proto change), pure time-based.

## Notes

- C++14; each commit builds clean and passes clang-format + clang-tidy.
- No changes to `ezio.proto` or `service.cpp`.