### PR TITLE
feat(app): add --port/-p option to set BitTorrent listen port

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Allowed Options:
   --aio-threads arg        threads for disk I/O and hashing (default 16)
   --slow-start             enable session-wide slow-start upload ramp (default off)
   --slow-start-period arg  slow-start step period in seconds (default 10)
+  -p [ --port ] arg        BitTorrent peer listen port (default 6881)
   -v [ --version ]         show version
 ```
 

--- a/app.cpp
+++ b/app.cpp
@@ -57,6 +57,15 @@ lt::session_params app::make_session_params(const config &cfg)
 	p.set_int(lt::settings_pack::cache_size, cache_blocks);
 	spdlog::info("Cache size: {} MB ({} blocks)", cfg.cache_size_mb, cache_blocks);
 
+	// BitTorrent peer listen port. Default bt_listen_port == 0 leaves
+	// libtorrent's listen_interfaces untouched (behavior unchanged); a
+	// non-zero value binds the BT peer port on every interface (IPv4 + IPv6).
+	if (cfg.bt_listen_port != 0) {
+		std::string listen_ifaces = "0.0.0.0:" + std::to_string(cfg.bt_listen_port) + ",[::]:" + std::to_string(cfg.bt_listen_port);
+		p.set_str(lt::settings_pack::listen_interfaces, listen_ifaces);
+		spdlog::info("BitTorrent listen port: {}", cfg.bt_listen_port);
+	}
+
 	lt::session_params ses_params(p);
 	if (!cfg.file_flag) {
 		ses_params.disk_io_constructor = raw_disk_io_constructor;

--- a/config.cpp
+++ b/config.cpp
@@ -16,6 +16,7 @@ void config::parse_from_argv(int argc, char **argv)
 		("aio-threads", bpo::value<int>(&aio_threads)->default_value(16), "number of threads for disk I/O and hashing, default is 16")
 		("slow-start", bpo::bool_switch(&slow_start)->default_value(false), "enable session-wide slow-start upload ramp (default off)")
 		("slow-start-period", bpo::value<int>(&slow_start_period)->default_value(10), "slow-start step period in seconds (default 10)")
+		("port,p", bpo::value<int>(&bt_listen_port)->default_value(0), "BitTorrent peer listen port (default 6881)")
 		("version,v", "show version")
 	;
 	// clang-format on

--- a/config.hpp
+++ b/config.hpp
@@ -29,6 +29,8 @@ public:
 	bool slow_start = false;
 	// slow-start step period in seconds
 	int slow_start_period = 10;	 // default 10 seconds
+	// BitTorrent peer listen port (0 = use libtorrent default, leave unchanged)
+	int bt_listen_port = 0;
 };
 
 }  // namespace ezio


### PR DESCRIPTION
## What

Adds a `--port` / `-p` CLI option to set the BitTorrent **peer** listen port.

```
-p [ --port ] arg        BitTorrent peer listen port (default 6881)
```

## Why

EZIO previously had no way to choose the BT listen port, so two `ezio`
instances could not coexist on one host. A configurable peer port (independent
of the gRPC `--listen` address) lets multiple instances run on the same
machine — e.g. a seeder + leecher loopback benchmark — and makes the BT port
explicit for firewall/port-mapping setups.

## Behaviour

- **Default `--port 0`**: leaves libtorrent's `listen_interfaces` untouched, so
  behaviour is unchanged (libtorrent's default port 6881).
- **Non-zero**: binds the BT peer port on every interface, IPv4 **and** IPv6,
  via `listen_interfaces = "0.0.0.0:<port>,[::]:<port>"`.
- Fully independent of the gRPC service `--listen` option.

## Changes

- `config.{hpp,cpp}`: new `bt_listen_port` field + `--port,-p` option (default 0).
- `app.cpp`: when non-zero, set `settings_pack::listen_interfaces` (IPv4+IPv6) and log the chosen port.
- `README.md`: document the option.

+13 lines, no behaviour change at the default.