### PR TITLE
refactor(cache): remove dead write-back-era dirty-block collectors

### DIFF
--- a/unified_cache.cpp
+++ b/unified_cache.cpp
@@ -119,41 +119,6 @@ void cache_partition::mark_clean(torrent_location const &loc)
 	}
 }
 
-std::vector<torrent_location> cache_partition::collect_dirty_blocks()
-{
-	std::vector<torrent_location> dirty_blocks;
-	dirty_blocks.reserve(m_entries.size());
-
-	// NOTE: C++17 could use structured bindings: for (auto &[loc, entry] : m_entries)
-	for (auto &pair : m_entries) {
-		// Collect dirty blocks
-		if (pair.second.dirty) {
-			dirty_blocks.push_back(pair.first);
-			// Clear dirty flag (will be written to disk)
-			pair.second.dirty = false;
-		}
-	}
-
-	return dirty_blocks;
-}
-
-std::vector<torrent_location> cache_partition::collect_dirty_blocks_for_storage(
-	libtorrent::storage_index_t storage)
-{
-	std::vector<torrent_location> dirty_blocks;
-	dirty_blocks.reserve(m_entries.size());
-
-	// Only collect dirty blocks for the specified storage
-	for (auto &pair : m_entries) {
-		if (pair.second.dirty && pair.first.torrent == storage) {
-			dirty_blocks.push_back(pair.first);
-			pair.second.dirty = false;
-		}
-	}
-
-	return dirty_blocks;
-}
-
 size_t cache_partition::clear_piece(libtorrent::storage_index_t storage,
 	libtorrent::piece_index_t piece)
 {
@@ -282,19 +247,6 @@ void unified_cache::mark_clean(torrent_location const &loc)
 	m_partitions[partition_idx]->mark_clean(loc);
 }
 
-std::vector<torrent_location> unified_cache::collect_dirty_blocks(libtorrent::storage_index_t storage)
-{
-	std::vector<torrent_location> all_dirty;
-
-	// Collect from all partitions, but only for the specified storage
-	for (size_t i = 0; i < m_partitions.size(); ++i) {
-		auto partition_dirty = m_partitions[i]->collect_dirty_blocks_for_storage(storage);
-		all_dirty.insert(all_dirty.end(), partition_dirty.begin(), partition_dirty.end());
-	}
-
-	return all_dirty;
-}
-
 size_t unified_cache::clear_piece(libtorrent::storage_index_t storage,
 	libtorrent::piece_index_t piece)
 {
@@ -322,24 +274,6 @@ size_t unified_cache::total_dirty_count() const
 		total += m_partitions[i]->dirty_count();
 	}
 	return total;
-}
-
-size_t unified_cache::get_dirty_count(libtorrent::storage_index_t storage)
-{
-	// Collect dirty blocks for this storage
-	size_t count = 0;
-
-	for (size_t i = 0; i < m_partitions.size(); ++i) {
-		auto partition_dirty = m_partitions[i]->collect_dirty_blocks();
-
-		for (auto const &loc : partition_dirty) {
-			if (loc.torrent == storage) {
-				++count;
-			}
-		}
-	}
-
-	return count;
 }
 
 void unified_cache::set_max_entries(size_t new_max)

--- a/unified_cache.hpp
+++ b/unified_cache.hpp
@@ -277,12 +277,6 @@ public:
 		return (it == m_entries.end()) ? 0 : it->second.length;
 	}
 
-	// Collect all dirty blocks in this partition and mark them as clean
-	std::vector<torrent_location> collect_dirty_blocks();
-
-	// Collect dirty blocks for a specific storage only
-	std::vector<torrent_location> collect_dirty_blocks_for_storage(libtorrent::storage_index_t storage);
-
 	// Remove all entries belonging to (storage, piece). Lock-free: owner-thread only.
 	size_t clear_piece(libtorrent::storage_index_t storage, libtorrent::piece_index_t piece);
 
@@ -403,9 +397,6 @@ public:
 		return m_partitions[partition_idx]->get_length(loc);
 	}
 
-	// Collect all dirty blocks for a storage
-	std::vector<torrent_location> collect_dirty_blocks(libtorrent::storage_index_t storage);
-
 	// Remove all cached entries for (storage, piece). Forwards to the owning partition.
 	// Lock-free: must be called from the owning worker thread.
 	size_t clear_piece(libtorrent::storage_index_t storage, libtorrent::piece_index_t piece);
@@ -413,7 +404,6 @@ public:
 	// Statistics
 	size_t total_entries() const;
 	size_t total_dirty_count() const;
-	size_t get_dirty_count(libtorrent::storage_index_t storage);
 	size_t max_entries() const
 	{
 		return m_max_entries;


### PR DESCRIPTION
## Summary

Removes `get_dirty_count()`, `collect_dirty_blocks()` and `collect_dirty_blocks_for_storage()` from `unified_cache` / `cache_partition` (-76 lines, pure deletion).

These are leftovers from the old delayed-write design. Since the switch to write-through caching there is no flusher that needs a dirty list, and nothing outside `unified_cache` references them.

## Why remove instead of keep

Beyond being dead code, they were landmines for future callers:

- **`get_dirty_count()` was a destructive query.** It routed through `collect_dirty_blocks()`, which cleared the `dirty` flag on every entry of **every storage across all partitions** as a side effect. Dirty entries are what LRU eviction pins while a `pwrite` is still in flight, so one innocent-looking stats call would un-pin in-flight writes and open a read-after-write window.
- **Owner-thread rule violation.** Both collectors mutate partition state (`m_entries`), which is only safe on the partition's owning worker thread; any stats/debug caller would run them from the wrong thread with no lock.
- **Counter drift.** They cleared dirty flags without decrementing `m_num_dirty`, so the counter drifted permanently upward.

## Verification

- `grep` confirms no remaining references outside the deleted definitions.
- `g++ -fsyntax-only` passes for `unified_cache.cpp` and `raw_disk_io.cpp` (only pre-existing `cache_size` deprecation warning).
- clang-format applied; diff is pure deletions, no behavior change.