### PR TITLE
refactor(cache): assert same-partition in get2, drop cross-partition path

### DIFF
--- a/unified_cache.hpp
+++ b/unified_cache.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <boost/asio/thread_pool.hpp>
+#include <boost/assert.hpp>
 #include <libtorrent/libtorrent.hpp>
 #include <spdlog/spdlog.h>
 
@@ -356,35 +357,19 @@ public:
 	}
 
 	// Get two entries at once
+	// Both locations must map to the same partition. The only call site passes
+	// two blocks of the same (storage, piece), and get_partition_index ignores
+	// the offset, so this always holds today. A cross-partition pair would mean
+	// touching a partition owned by another thread, breaking the lock-free
+	// owner-thread model -- assert so any future routing change (e.g. hashing
+	// by chunk/offset) fails fast here instead of racing silently.
 	template<typename Fun>
 	int get2(torrent_location const &loc1, torrent_location const &loc2, Fun f)
 	{
-		size_t partition_idx1 = get_partition_index(loc1);
-		size_t partition_idx2 = get_partition_index(loc2);
+		size_t const partition_idx = get_partition_index(loc1);
+		BOOST_ASSERT(partition_idx == get_partition_index(loc2));
 
-		// If same partition, use single-partition get2
-		if (partition_idx1 == partition_idx2) {
-			return m_partitions[partition_idx1]->get2(loc1, loc2, f);
-		}
-
-		// Different partitions - need to handle separately
-		// Get from partition 1
-		char const *buf1 = nullptr;
-		bool found1 = m_partitions[partition_idx1]->get(loc1, [&](char const *b) {
-			buf1 = b;
-		});
-
-		// Get from partition 2
-		char const *buf2 = nullptr;
-		bool found2 = m_partitions[partition_idx2]->get(loc2, [&](char const *b) {
-			buf2 = b;
-		});
-
-		if (!found1 && !found2) {
-			return 0;
-		}
-
-		return f(buf1, buf2);
+		return m_partitions[partition_idx]->get2(loc1, loc2, f);
 	}
 
 	// Mark as clean after writeback completes


### PR DESCRIPTION
## Summary

Replaces the cross-partition branch in `unified_cache::get2()` with a `BOOST_ASSERT` that both locations map to the same partition (+10/-25 lines).

## Why

**The branch was unreachable.** `get2()` has exactly one call site — the unaligned path of `async_read` — which passes two blocks of the same `(storage, piece)`. `get_partition_index()` deliberately ignores the offset, so both locations always hash to the same partition. The BitTorrent protocol guarantees a peer request never crosses a piece boundary, so the precondition holds structurally.

**Worse than dead, it was a latent data race.** The branch called `get()` on a partition owned by another worker thread and used the returned buffer pointers outside the owner thread — a violation of the lock-free 1:1 thread:partition model. It could never fire today, but if piece-level routing is ever revisited (e.g. the chunk-granularity routing idea recorded in the docs), this code would have silently become a real cross-thread race.

**The assert makes that future change fail fast.** Anyone who changes routing so that two blocks of one piece land in different partitions now hits an assertion at the call site immediately, instead of debugging silent data corruption in production.

## Verification

- Full `cmake --build` passes (only the pre-existing `cache_size` deprecation warning).
- No behavior change: the surviving code path is byte-for-byte the same-partition path that was always taken.
- clang-format applied.