### PR TITLE
refactor(disk_io): remove unused global raw_disk_io instance pointer

### DIFF
--- a/raw_disk_io.cpp
+++ b/raw_disk_io.cpp
@@ -18,10 +18,6 @@ namespace ezio
 constexpr size_t READ_POOL_SIZE = 512ULL * 1024 * 1024;
 constexpr size_t WRITE_POOL_SIZE = 512ULL * 1024 * 1024;
 
-// Global pointer to raw_disk_io instance for stats reporting
-// Set by raw_disk_io_constructor, accessed by log thread
-static raw_disk_io *g_raw_disk_io_instance = nullptr;
-
 // Helper function: Get cache entries from settings_pack::cache_size
 // cache_size is number of 16KiB blocks (libtorrent definition)
 // Returns number of 16KB entries
@@ -42,14 +38,7 @@ std::unique_ptr<libtorrent::disk_interface> raw_disk_io_constructor(libtorrent::
 	libtorrent::settings_interface const &s,
 	libtorrent::counters &c)
 {
-	auto disk_io = std::make_unique<raw_disk_io>(ioc, s, c);
-	g_raw_disk_io_instance = disk_io.get();
-	return disk_io;
-}
-
-raw_disk_io *get_raw_disk_io_instance()
-{
-	return g_raw_disk_io_instance;
+	return std::make_unique<raw_disk_io>(ioc, s, c);
 }
 
 raw_disk_io::raw_disk_io(libtorrent::io_context &ioc,

--- a/raw_disk_io.hpp
+++ b/raw_disk_io.hpp
@@ -21,10 +21,6 @@ raw_disk_io_constructor(libtorrent::io_context &ioc,
 	libtorrent::settings_interface const &,
 	libtorrent::counters &);
 
-// Get global raw_disk_io instance (set by raw_disk_io_constructor)
-// Returns nullptr if using default disk_io or before construction
-raw_disk_io *get_raw_disk_io_instance();
-
 class raw_disk_io final : public libtorrent::disk_interface
 {
 private:


### PR DESCRIPTION
## Summary

Removes `g_raw_disk_io_instance` and `get_raw_disk_io_instance()` (+1/-16 lines). Scope intentionally kept minimal per review discussion — diagnostics methods (`log_cache_stats` / `reset_cache_stats` and the `unified_cache` stats API) are **kept** for possible future debugging use.

## Why

- **Born dead:** both the global pointer and the internal stats thread were added in the same commit (`1be7efb`). The pointer's comment says "accessed by log thread", but that plan was superseded within the same commit by the self-contained `m_stats_thread` that pushes stats itself. `get_raw_disk_io_instance()` has never had a caller.
- **Dangling pointer:** the pointer was never cleared on destruction, so after the session tears down the disk_io it dangles; any future caller of the getter would get a dead object.

## Verification

- Full `cmake --build` passes.
- `grep` confirms the getter had no callers anywhere in the repo.
- clang-format applied.