### PR TITLE
fix(cache): make partition max_entries atomic

### DIFF
--- a/unified_cache.cpp
+++ b/unified_cache.cpp
@@ -49,13 +49,14 @@ bool cache_partition::insert(torrent_location const &loc, char const *data, int 
 	// relying on this path to gradually shrink the partition on subsequent inserts.
 	// libtorrent 2.x design: allow over-allocation (short-term exceeding max_entries)
 	// This prevents blocking writes when all entries are temporarily dirty
+	size_t const max_entries = m_max_entries.load(std::memory_order_relaxed);
 	bool did_evict = false;
-	while (m_entries.size() >= m_max_entries) {
+	while (m_entries.size() >= max_entries) {
 		if (!evict_one_lru()) {
 			// Cannot evict (all clean entries exhausted)
 			// Allow over-allocation - insert anyway
 			spdlog::debug("[cache_partition] Over-allocation: size={}, max={}",
-				m_entries.size() + 1, m_max_entries);
+				m_entries.size() + 1, max_entries);
 			break;
 		}
 		did_evict = true;
@@ -170,7 +171,7 @@ void cache_partition::set_max_entries(size_t new_max)
 	// by the worker thread (1:1 mapping) and evicting here would race with
 	// concurrent insert/lookup on the worker thread.
 	// Eviction happens naturally in insert() on the owning worker thread.
-	m_max_entries = new_max;
+	m_max_entries.store(new_max, std::memory_order_relaxed);
 }
 
 bool cache_partition::evict_one_lru()

--- a/unified_cache.hpp
+++ b/unified_cache.hpp
@@ -163,7 +163,11 @@ private:
 	// Single LRU list (all blocks, both dirty and clean)
 	std::list<torrent_location> m_lru;	// unified LRU list
 
-	size_t m_max_entries;
+	// Written by the network thread via set_max_entries(); read by the owning
+	// worker thread in insert(). Atomic (relaxed) so the cross-thread access is
+	// well-defined; no ordering is needed, a stale limit only changes how many
+	// entries the next insert() evicts.
+	std::atomic<size_t> m_max_entries;
 	cache_partition_stats_internal m_stats;	 // Performance statistics (atomic)
 
 	// Dirty block tracking
@@ -286,7 +290,7 @@ public:
 	size_t dirty_count() const;
 	size_t max_entries() const
 	{
-		return m_max_entries;
+		return m_max_entries.load(std::memory_order_relaxed);
 	}
 
 	// Dynamic resize


### PR DESCRIPTION
## Summary

Makes `cache_partition::m_max_entries` a `std::atomic<size_t>` with relaxed ordering (+10/-5 lines). Follow-up from the review discussion on `set_max_entries()` thread-safety.

## The race

- **Writer:** network thread, via `settings_updated()` → `unified_cache::set_max_entries()` → `cache_partition::set_max_entries()`.
- **Reader:** the owning worker thread, in `insert()`'s eviction loop (`while (m_entries.size() >= m_max_entries)`).

A plain `size_t` makes this a data race under the C++ memory model. In practice the exposure is near zero — an aligned `size_t` does not tear on x86/ARM64, and nothing in EZIO changes `cache_size` at runtime today — but the fix costs nothing, so make it well-defined.

## Why relaxed is enough

No ordering is needed: a stale limit only changes how many entries the next `insert()` evicts, and the following insert converges. The deferred-eviction design (limit updated on the network thread, actual eviction only on the owner thread) is unchanged.

`insert()` now loads the limit once per call, so the eviction loop and the over-allocation debug log see one consistent value (spdlog/fmt also cannot format a `std::atomic` directly).

`unified_cache::m_max_entries` stays plain — it is only ever accessed on the network thread (constructor, `set_max_entries`, `settings_updated`).

## Verification

- Full `cmake --build` passes.
- No behavior change on any current code path.
- clang-format applied.