### PR TITLE
docs: sync buffer pool and cache comments with code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,12 @@ EZIO is a **BitTorrent-based raw disk imaging tool** for fast LAN deployment.
 
 1. **Raw disk I/O** — pread/pwrite to a partition, no filesystem layer.
 
-2. **Unified buffer pool** (`buffer_pool`, 256 MB) — single pool of temporary
-   I/O buffers for read/write/hash. Dynamic allocation, watermarks (50% low,
-   87.5% high). This is *not* a cache.
+2. **Split buffer pools** (`buffer_pool` x2, 512 MB each) — temporary I/O
+   buffers: one pool for read + hash, one for write. Soft limit: allocation
+   only fails on real malloc failure; the high watermark (87.5%) raises the
+   backpressure (`exceeded`) flag, released at the low watermark (50%).
+   This is *not* a cache. (History: split -> merged 256 MB -> re-split
+   `f8e00ab` -> 512 MB each `0a5c885`.)
 
 3. **Lock-free unified cache** (`m_cache`, default 512 MB, `--cache-size`)
    - Write-through cache; **replaced the old `store_buffer`**.
@@ -81,7 +84,7 @@ EZIO is a **BitTorrent-based raw disk imaging tool** for fast LAN deployment.
 | Area | Description | Benefit |
 |------|-------------|---------|
 | Logging | Runtime log level via env; event-driven alerts | 5000x faster alert response |
-| Buffer pool | Merged split pools into one 256 MB pool | +48% memory efficiency |
+| Buffer pool | Merged into one 256 MB pool (+48% memory efficiency); later re-split into read/write pools, 512 MB each | See fact 2 above |
 | Settings | Constructor takes settings/counters; configurable thread pools | Runtime tuning, no recompile |
 | Lock-free cache | Write-through cache, 1:1 thread:partition, consistent hashing | +184% (270 -> 766 MB/s 1-on-1), 98-100% hit rate |
 | UI refactor | Component-based TUI: sorting, filtering, color, scrollbar, help | -743 lines, more features |
@@ -262,7 +265,7 @@ persistent seed; benchmark only, do not assume positive.
 
 **Code:**
 - `raw_disk_io.hpp` / `raw_disk_io.cpp` — main disk I/O (async_read/write/hash)
-- `buffer_pool.hpp` / `buffer_pool.cpp` — unified buffer pool
+- `buffer_pool.hpp` / `buffer_pool.cpp` — split read/write buffer pools
 - the lock-free cache (`m_cache`) and `partition_storage`
 
 **Docs:**

--- a/raw_disk_io.hpp
+++ b/raw_disk_io.hpp
@@ -24,11 +24,13 @@ raw_disk_io_constructor(libtorrent::io_context &ioc,
 class raw_disk_io final : public libtorrent::disk_interface
 {
 private:
-	// Split buffer pools (128MB each, no over-allocation)
+	// Split buffer pools (READ_POOL_SIZE / WRITE_POOL_SIZE, 512 MB each).
+	// Soft limit: allocation only fails on real malloc failure; the watermarks
+	// drive the exceeded/backpressure flag (see buffer_pool.cpp).
 	buffer_pool m_read_buffer_pool;	 // Read + hash operations
 	buffer_pool m_write_buffer_pool;  // Write operations
 
-	unified_cache m_cache;	// Persistent cache (512MB, delayed write + read cache)
+	unified_cache m_cache;	// Write-through cache (cache_size setting, default 512 MB)
 
 	// Per-thread pool for consistent hashing (each pool has 1 thread)
 	// Each thread owns its cache partition exclusively (lock-free!)


### PR DESCRIPTION
## Summary

Fixes stale comments that described the buffer pool three different ways across the codebase (+12/-7 lines, comments and docs only — no code change).

## What drifted

The code is the truth: **two split pools, 512 MB each** (`READ_POOL_SIZE` / `WRITE_POOL_SIZE` in `raw_disk_io.cpp`), since `f8e00ab` re-split the pools and `0a5c885` bumped them to 512 MB. But:

- `raw_disk_io.hpp` said "Split buffer pools (**128MB** each, no over-allocation)"
- `CLAUDE.md` said "**Unified** buffer pool (**256 MB**) — single pool"

Three stories for one allocation; anyone doing memory-budget planning from the docs would be off by 4-8x.

## Changes

- `raw_disk_io.hpp`: pool comment now points at the constants (512 MB each) and describes the soft-limit/watermark behavior instead of the incorrect "no over-allocation"; `m_cache` comment corrected from "delayed write" to write-through (with size source).
- `CLAUDE.md` fact 2: rewritten to describe the split pools and the watermark/backpressure semantics, with a one-line history trail (split → merged 256 MB → re-split → 512 MB each).
- `CLAUDE.md` Completed Work table + Key Files: updated to note the later re-split so the historical "+48% merge" row can't be read as current state.

## Verification

Build passes (comment-only change in the header).