### PR TITLE
fix(service): fail startup when gRPC server cannot bind

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -93,7 +93,9 @@ app::app(const config &cfg) : m_config(cfg), m_session(make_session_params(cfg))
 
 int app::run()
 {
-	m_service.start(m_config.listen_address);
+	if (!m_service.start(m_config.listen_address)) {
+		return 1;
+	}
 	m_log.start();
 	spdlog::info("Server listening on {}", m_config.listen_address);
 	m_daemon.run();

--- a/service.cpp
+++ b/service.cpp
@@ -9,7 +9,7 @@ gRPCService::gRPCService(ezio &daemon) :
 {
 }
 
-void gRPCService::start(std::string listen_address)
+bool gRPCService::start(std::string listen_address)
 {
 	ServerBuilder builder;
 	builder.AddListeningPort(listen_address, grpc::InsecureServerCredentials());
@@ -17,16 +17,27 @@ void gRPCService::start(std::string listen_address)
 	builder.SetMaxReceiveMessageSize(-1);
 	builder.RegisterService(this);
 	m_server = builder.BuildAndStart();
+	// BuildAndStart returns nullptr when the address is invalid or the port
+	// is already taken (e.g. a second ezio instance).
+	if (!m_server) {
+		spdlog::critical("failed to start gRPC server on {} (address in use or invalid?)", listen_address);
+		return false;
+	}
+	return true;
 }
 
 void gRPCService::stop()
 {
-	m_server->Shutdown(std::chrono::system_clock::now() + std::chrono::seconds(10));
+	if (m_server) {
+		m_server->Shutdown(std::chrono::system_clock::now() + std::chrono::seconds(10));
+	}
 }
 
 void gRPCService::wait()
 {
-	m_server->Wait();
+	if (m_server) {
+		m_server->Wait();
+	}
 }
 
 Status gRPCService::Shutdown(ServerContext *context, const Empty *e1,

--- a/service.hpp
+++ b/service.hpp
@@ -33,7 +33,8 @@ class gRPCService final : public EZIO::Service
 public:
 	gRPCService(ezio &);
 	explicit gRPCService();
-	void start(std::string);
+	// Returns false if the server failed to start (e.g. listen address in use).
+	bool start(std::string);
 	void stop();
 	void wait();
 


### PR DESCRIPTION
## Summary

`ServerBuilder::BuildAndStart()` returns `nullptr` when the listen address is invalid or unusable. `gRPCService::start()` stored it blindly, so ezio would log "Server listening on ...", run the entire session **without a control interface**, and then crash with a null dereference in `stop()` at shutdown.

## Changes

- `start()` now returns `bool`; on `nullptr` it logs `critical` and returns false.
- `app::run()` aborts with exit code 1 instead of continuing.
- `stop()` / `wait()` guard against a null `m_server` so they are safe in any order.

## Verified end-to-end

Ran the built binary with an invalid listen address (`-l 999.999.999.999:50051`):

- before: "Server listening" logged, daemon runs headless, crash at shutdown
- after: `critical` log ("failed to start gRPC server on ..."), clean session teardown, **exit code 1**

One finding from testing worth knowing: on Linux a **duplicate port does not fail** — gRPC enables `SO_REUSEPORT` by default, so a second ezio instance binds the same gRPC port successfully and the kernel load-balances requests between the two instances. The nullptr path triggers on invalid/unbindable addresses. (Also noticed during the test: process exit takes ~30 s because the stats thread sleeps in 30 s slices before its join — that is the known shutdown-latency item on the review list, separate PR.)