### PR TITLE
fix(disk_io): make stats thread shutdown interruptible

### DIFF
--- a/raw_disk_io.cpp
+++ b/raw_disk_io.cpp
@@ -97,8 +97,13 @@ raw_disk_io::~raw_disk_io()
 {
 	spdlog::info("[raw_disk_io] Shutting down: waiting for all I/O to complete...");
 
-	// Stop stats reporting thread first
-	m_shutdown = true;
+	// Stop stats reporting thread first, waking it out of its 30s wait so
+	// shutdown does not stall until the next report tick.
+	{
+		std::lock_guard<std::mutex> lock(m_shutdown_mutex);
+		m_shutdown = true;
+	}
+	m_shutdown_cv.notify_all();
 	if (m_stats_thread.joinable()) {
 		m_stats_thread.join();
 	}
@@ -619,12 +624,19 @@ void raw_disk_io::stats_report_loop()
 {
 	spdlog::info("[raw_disk_io] Cache stats reporting thread started (30s interval)");
 
+	std::unique_lock<std::mutex> lock(m_shutdown_mutex);
 	while (!m_shutdown) {
-		std::this_thread::sleep_for(std::chrono::seconds(30));
-
-		if (m_shutdown) {
+		// Interruptible sleep: wait_for returns true when the destructor sets
+		// m_shutdown and notifies, so shutdown does not wait out the interval.
+		if (m_shutdown_cv.wait_for(lock, std::chrono::seconds(30),
+				[this] {
+					return m_shutdown.load();
+				})) {
 			break;
 		}
+
+		// Report without holding the lock; it only guards the flag/CV.
+		lock.unlock();
 
 		// Buffer pool usage stats (split pools)
 		int read_in_use = m_read_buffer_pool.in_use();
@@ -666,6 +678,8 @@ void raw_disk_io::stats_report_loop()
 					i, entries, usage, p_ops, p_hit_rate);
 			});
 		}
+
+		lock.lock();
 	}
 
 	spdlog::info("[raw_disk_io] Cache stats reporting thread exiting");

--- a/raw_disk_io.hpp
+++ b/raw_disk_io.hpp
@@ -6,6 +6,8 @@
 #include <deque>
 #include <vector>
 #include <thread>
+#include <mutex>
+#include <condition_variable>
 #include <libtorrent/libtorrent.hpp>
 #include <boost/asio.hpp>
 #include "buffer_pool.hpp"
@@ -42,6 +44,11 @@ private:
 	// Cache statistics reporting (temporary for debugging)
 	std::thread m_stats_thread;
 	std::atomic<bool> m_shutdown{false};
+	// Wakes the stats thread out of its 30s wait so the destructor's join
+	// does not stall shutdown. m_shutdown is set under m_shutdown_mutex to
+	// avoid a lost wakeup against the wait_for predicate check.
+	std::mutex m_shutdown_mutex;
+	std::condition_variable m_shutdown_cv;
 
 	// callbacks are posted on this (main network I/O context)
 	libtorrent::io_context &m_ioc;


### PR DESCRIPTION
## Summary

`stats_report_loop()` slept in fixed 30 s slices (`std::this_thread::sleep_for`) and `~raw_disk_io()` joins the thread, so any session teardown — Ctrl-C, gRPC Shutdown, or a startup failure — stalled up to 30 seconds waiting out the sleep.

Replace the sleep with a `condition_variable::wait_for`; the destructor sets `m_shutdown` and notifies, waking the thread immediately.

## Measured

Using the startup-failure path from #150 (invalid listen address → clean exit):

| | teardown time |
|---|---|
| before | ~30 s |
| after | **0.06 s** |

## Why the new mutex is safe

- **Never touches the I/O paths.** Only the stats thread (while waiting) and the destructor (for the instant it sets the flag) take `m_shutdown_mutex`. `async_read`/`async_write`/`async_hash` and the worker threads never see it — the lock-free model is untouched.
- **No deadlock.** The destructor releases the mutex (scope block) *before* `join()`, and the stats thread runs its report body *unlocked* (`lock.unlock()` around the body), so neither side ever waits on the other while holding the lock.
- **No lost wakeup.** The flag is set under the mutex; the stats thread holds the mutex from the loop-condition check into `wait_for` (which releases it atomically), so the set-then-notify cannot fall into the gap. If the notify lands while the thread is in the report body, the loop condition catches the flag on reentry.