### PR TITLE
fix(cache): drop stale LRU nodes instead of skipping them

### DIFF
--- a/unified_cache.cpp
+++ b/unified_cache.cpp
@@ -178,10 +178,21 @@ bool cache_partition::evict_one_lru()
 {
 	// Single LRU eviction: scan from LRU end for first clean block
 	// Skip dirty blocks (cannot evict while pending write)
-	for (auto it = m_lru.rbegin(); it != m_lru.rend(); ++it) {
+	auto it = m_lru.rbegin();
+	while (it != m_lru.rend()) {
 		auto entry_it = m_entries.find(*it);
 		if (entry_it == m_entries.end()) {
-			spdlog::error("[cache_partition] LRU inconsistency: entry not found");
+			// Should not happen: insert/get/clear_piece keep m_entries and
+			// m_lru in sync. If it does, drop the stale node so the error is
+			// logged once instead of on every eviction pass forever (nothing
+			// else can remove an orphaned node: all other removal paths go
+			// through the map entry's lru_iter).
+			spdlog::error("[cache_partition] LRU inconsistency: entry not found, dropping stale node");
+			// erase() takes the forward iterator to *it and returns the next
+			// forward position; wrapping that in a reverse_iterator resumes
+			// the reverse scan at the element preceding the erased node.
+			it = std::list<torrent_location>::reverse_iterator(
+				m_lru.erase(std::next(it).base()));
 			continue;
 		}
 
@@ -193,6 +204,8 @@ bool cache_partition::evict_one_lru()
 			m_stats.evictions++;
 			return true;
 		}
+
+		++it;
 	}
 
 	// All entries are dirty - cannot evict


### PR DESCRIPTION
## Summary

`evict_one_lru()` has a defensive check for an LRU-list node whose key is missing from `m_entries`. On hit it logged an error and `continue`d — leaving the orphaned node in the list **forever**: every other removal path (eviction, `clear_piece`) reaches the list through the map entry's `lru_iter`, so nothing else can ever delete an orphan.

Consequences of the old behavior once a node went stale:
- every subsequent eviction pass re-hits it and repeats the same error line — log flooding at eviction rates (hundreds/s on a full cache), burying real signals;
- one wasted map lookup per eviction, permanently.

## Change

Erase the stale node in place and resume the reverse scan at the preceding element. The loop is restructured `for` → `while` because the reverse_iterator rewrap after `erase()` already advances the scan position — a second `++it` from the `for` header would skip an element.

This is defense-in-depth, not a live-bug fix: `insert`/`get`/`clear_piece` maintain both structures in lockstep, so the condition remains should-not-happen. The change is strictly about the failure mode: permanent log flooding → log once, self-heal, keep serving.

## Verification

- Full `cmake --build` passes.
- The reverse-scan erase pattern (the tricky part — `reverse_iterator(erase(next(it).base()))`) was verified in a standalone program under **ASan + UBSan**: stale node at front / back / middle, consecutive stale nodes, all-stale, and single-element lists all visit the remaining elements exactly once, in order, with no invalid iterator use.