### PR TITLE
ci: add CodeQL and OpenSSF Scorecard, plus verifiable README badges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,15 @@
 version: 2
 
 updates:
-  # Keep the SHA-pinned actions in .github/workflows/ fresh.
+  # Workflows reference actions by floating major tag (actions/checkout@v6), so
+  # minor and patch upgrades arrive on their own and Dependabot stays quiet.
+  # What this rule is actually for is the major bumps: it opens a PR when
+  # actions/checkout@v7 or codeql-action@v5 lands, which is otherwise easy to
+  # miss until an old major is deprecated.
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
     commit-message:
       prefix: ci
     labels:
@@ -15,14 +18,3 @@ updates:
       github-actions:
         patterns:
           - "*"
-
-  # gRPC client helpers under utils/
-  - package-ecosystem: pip
-    directory: /utils
-    schedule:
-      interval: weekly
-      day: monday
-    commit-message:
-      prefix: build
-    labels:
-      - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+
+updates:
+  # Keep the SHA-pinned actions in .github/workflows/ fresh.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: ci
+    labels:
+      - dependencies
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # gRPC client helpers under utils/
+  - package-ecosystem: pip
+    directory: /utils
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: build
+    labels:
+      - dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,80 @@
+name: CodeQL
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    # Same weekly slot as the build test, offset to avoid competing for runners
+    - cron: '30 12 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      # required to upload the SARIF results to code scanning
+      security-events: write
+      # required by github/codeql-action to read the workflow run status
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # C++ daemon: needs a real compile, so CodeQL traces a manual build
+          - language: c-cpp
+            build-mode: manual
+          # utils/ gRPC client scripts
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      # Mirrors the builder stage of the Dockerfile
+      - name: Install build dependencies
+        if: matrix.build-mode == 'manual'
+        run: |
+          sudo apt-get -y update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            libssl-dev \
+            cmake \
+            make \
+            libgrpc-dev \
+            libgrpc++-dev \
+            libprotobuf-dev \
+            protobuf-compiler-grpc \
+            libtorrent-rasterbar-dev \
+            libboost-program-options-dev \
+            libspdlog-dev
+
+      - name: Build EZIO
+        if: matrix.build-mode == 'manual'
+        run: |
+          cmake -B build -S .
+          cmake --build build -j "$(nproc)"
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,13 @@ on:
 permissions:
   contents: read
 
+# The c-cpp job takes ~5 min, so don't let consecutive pushes to a PR stack up
+# runners. Pushes to master still run to completion so the Security tab stays
+# in sync with the branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -39,12 +46,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -75,6 +82,6 @@ jobs:
           cmake --build build -j "$(nproc)"
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: build test with container

--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -11,13 +11,18 @@ on:
       - master
     tags: '*'
 
+permissions:
+  contents: read
+
 jobs:
   build_test:
     name: Run build test
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: build test with container
         run:
           docker build . -t ezio_ci_test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,21 +6,16 @@ on:
       - 'v*'  # Trigger on version tags (v1.0.0, v2.0.16, etc.)
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
-    permissions:
-      # needed to create the GitHub release
-      contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-        with:
-          persist-credentials: false
+        uses: actions/checkout@v6
       - name: Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        uses: softprops/action-gh-release@v3
         with:
           prerelease: >-
             ${{

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,16 +6,21 @@ on:
       - 'v*'  # Trigger on version tags (v1.0.0, v2.0.16, etc.)
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    permissions:
+      # needed to create the GitHub release
+      contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - name: Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           prerelease: >-
             ${{

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,6 +15,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       # required to upload the SARIF results to code scanning
       security-events: write
@@ -25,12 +26,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        uses: ossf/scorecard-action@v2
         with:
           results_file: results.sarif
           results_format: sarif
@@ -39,13 +40,13 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,51 @@
+name: OpenSSF Scorecard
+
+on:
+  # Re-run whenever branch protection changes, so the badge stays accurate
+  branch_protection_rule:
+  schedule:
+    - cron: '0 6 * * 1'
+  push:
+    branches:
+      - master
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # required to upload the SARIF results to code scanning
+      security-events: write
+      # required by the OIDC token exchange used to publish results
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the OpenSSF REST API. This is what backs the README badge
+          # and it only works on a public repository.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # EZIO
 
-![build test](https://github.com/tjjh89017/ezio/actions/workflows/github_actions.yml/badge.svg)
+[![build test](https://github.com/tjjh89017/ezio/actions/workflows/github_actions.yml/badge.svg)](https://github.com/tjjh89017/ezio/actions/workflows/github_actions.yml)
+[![CodeQL](https://github.com/tjjh89017/ezio/actions/workflows/codeql.yml/badge.svg)](https://github.com/tjjh89017/ezio/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/tjjh89017/ezio/badge)](https://scorecard.dev/viewer/?uri=github.com/tjjh89017/ezio)
+
+[![release](https://img.shields.io/github/v/release/tjjh89017/ezio?sort=semver&logo=github)](https://github.com/tjjh89017/ezio/releases/latest)
+[![license](https://img.shields.io/github/license/tjjh89017/ezio)](LICENSE)
 
 **EZIO is a high-performance disk imaging tool for rapidly deploying dozens to hundreds of machines over a LAN.** It distributes disk images peer-to-peer with the BitTorrent protocol and writes directly to raw disk partitions, achieving far faster deployment than traditional multicast — and it gets *faster* as you add more clients, because every client also seeds.
 
@@ -404,6 +409,7 @@ Result is stable across `--cache-size` (512 MB–2 GB) and `--aio-threads` (8–
 - Issues: https://github.com/tjjh89017/ezio/issues
 - Source: https://github.com/tjjh89017/ezio
 - Maintainer email: tjjh89017@hotmail.com
+- Security vulnerabilities: please report them privately, see [SECURITY.md](SECURITY.md)
 
 **Special thanks** to the National Center for High-performance Computing (NCHC), Taiwan, for test hardware and support.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,64 @@
+# Security Policy
+
+## Supported Versions
+
+EZIO is developed on `master` and shipped as tagged releases. Only the latest
+release line receives security fixes; older tags are not backported.
+
+| Version         | Supported          |
+| --------------- | ------------------ |
+| latest `v2.0.x` | :white_check_mark: |
+| older tags      | :x:                |
+
+If you use EZIO through Clonezilla Lite Server, also report the issue to the
+[Clonezilla project](https://clonezilla.org/) so the bundled copy gets updated.
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for a security vulnerability.**
+
+Report it privately through GitHub's coordinated disclosure flow:
+
+1. Go to <https://github.com/tjjh89017/ezio/security/advisories/new>.
+2. Describe the issue, the affected version or commit, and the impact.
+3. Include reproduction steps: the command line used, the torrent/partition
+   layout, and any relevant `ezio` log output (run with a raised log level).
+
+If GitHub private reporting is unavailable to you, contact the maintainer
+listed in [.github/CODEOWNERS](.github/CODEOWNERS) directly instead.
+
+### What to expect
+
+- **Acknowledgement:** within 7 days.
+- **Assessment:** a severity judgement and a fix plan within 30 days.
+- **Disclosure:** the advisory is published once a fixed release is tagged.
+  Reporters are credited unless they ask not to be.
+
+This is a volunteer-maintained project, so timelines are best effort.
+
+## Scope
+
+EZIO writes directly to raw block devices and moves disk images over the
+BitTorrent protocol, so the following are in scope:
+
+- Memory-safety issues in the disk I/O, cache, or torrent handling paths
+  (`raw_disk_io`, `unified_cache`, `buffer_pool`, `partition_storage`).
+- Anything that lets a remote peer cause a write outside the offsets declared
+  by the torrent, or otherwise corrupt the target partition.
+- Authentication or authorisation flaws in the gRPC control service.
+
+The following are **out of scope** — they are documented design properties of
+a LAN deployment tool, not defects:
+
+- The gRPC control service and the BitTorrent tracker are unauthenticated and
+  unencrypted by design. EZIO is intended for a trusted deployment LAN; do not
+  expose these ports to an untrusted network.
+- Running `ezio` as root and destroying data on the target partition. That is
+  the tool's purpose.
+
+## Security Practices
+
+This repository runs [CodeQL](https://codeql.github.com/) static analysis on
+every push and pull request, and publishes an
+[OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/tjjh89017/ezio)
+report weekly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,10 @@
 
 ## Supported Versions
 
-EZIO is developed on `master` and shipped as tagged releases. Only the latest
-release line receives security fixes; older tags are not backported.
-
-| Version         | Supported          |
-| --------------- | ------------------ |
-| latest `v2.0.x` | :white_check_mark: |
-| older tags      | :x:                |
+EZIO is developed on `master` and shipped as tagged releases. Security fixes go
+into the latest release line only; older tags are not backported. If you are
+running anything other than the most recent release, upgrade first and check
+whether the issue still reproduces.
 
 If you use EZIO through Clonezilla Lite Server, also report the issue to the
 [Clonezilla project](https://clonezilla.org/) so the bundled copy gets updated.
@@ -24,8 +21,8 @@ Report it privately through GitHub's coordinated disclosure flow:
 3. Include reproduction steps: the command line used, the torrent/partition
    layout, and any relevant `ezio` log output (run with a raised log level).
 
-If GitHub private reporting is unavailable to you, contact the maintainer
-listed in [.github/CODEOWNERS](.github/CODEOWNERS) directly instead.
+If GitHub private reporting is unavailable to you, email the maintainer
+directly at <tjjh89017@hotmail.com> instead.
 
 ### What to expect
 


### PR DESCRIPTION
## What

Adds security automation and the badges that report it.

**New workflows**

- **`.github/workflows/codeql.yml`** — CodeQL `security-extended` on two languages:
  - `c-cpp` with `build-mode: manual`, installing the same apt packages as the Dockerfile builder stage and running `cmake -B build && cmake --build build`.
  - `python` with `build-mode: none` for the `utils/` gRPC helpers.
  - Triggers: push/PR on `master`, weekly (`30 12 * * 1`, offset from the existing build test), and `workflow_dispatch`.
- **`.github/workflows/scorecard.yml`** — weekly OpenSSF Scorecard with `publish_results: true` (required for the README badge to resolve) and the SARIF uploaded to code scanning.

**Supporting hardening** (these are Scorecard checks, they move the score directly)

- `.github/dependabot.yml` — weekly `github-actions` (grouped) and `pip` (`utils/requirements.txt`) updates. Also what keeps the SHA pins below from going stale.
- `SECURITY.md` — private disclosure via GitHub security advisories, expected response times, and an explicit **scope** section stating that the unauthenticated gRPC service and tracker are a documented property of a trusted-LAN deployment tool, not a vulnerability. Without that, EZIO will attract "your gRPC port has no auth" reports.
- Existing workflows: top-level `permissions: contents: read`; `release.yml` keeps `contents: write` but pushed down to the job that needs it; actions pinned by commit SHA with a `# vX.Y.Z` comment; `persist-credentials: false` on checkout.

**README badges** — build test (now linked, it was a bare image), CodeQL, OpenSSF Scorecard, latest release, license. Everything on the row is machine-verifiable; no static "made with X" decoration.

## Verification

The CodeQL C++ build is the risky part, so it was dry-run on a fork before opening this — `ubuntu-latest` does carry `libtorrent-rasterbar-dev` 2.0, `libgrpc++-dev`, `libspdlog-dev` and Boost 1.83, and the build traces cleanly.

- Both matrix jobs green: [run 31359880662](https://github.com/mangokingTW/ezio/actions/runs/31359880662) (~5 min for `c-cpp`, ~1 min for `python`).
- **Zero open alerts** on `security-extended`.
- For reference, `security-and-quality` was tried first and produced 220 `note`-level style findings (157 × `cpp/commented-out-code`), so `security-extended` was chosen instead — full security coverage, no style noise in the Security tab.

## After merge

- The Scorecard badge stays grey until the workflow runs once on `master`; it can be triggered immediately from the Actions tab.
- CodeQL results need **Code scanning** enabled under Settings → Code security.
- Two Scorecard checks cannot be fixed from a PR and need repo settings: **Branch-Protection** on `master` (require a PR + a review), and **Signed-Releases** (release artifacts / provenance attestation).
- `Dockerfile`'s `FROM debian:sid` is left unpinned. Scorecard's Pinned-Dependencies will dock a point for it, but pinning a digest defeats the point of tracking sid — deliberate trade-off.