### PR TITLE
docs: add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,76 @@
+cff-version: 1.2.0
+title: EZIO
+message: >-
+  If you use this software in your research, please cite it using the metadata
+  below. If you are citing the mechanism rather than the implementation, cite
+  the IEEE Access 2021 paper listed under references.
+type: software
+authors:
+  - given-names: Yu-Chiang
+    family-names: Huang
+abstract: >-
+  EZIO is a high-performance disk imaging tool for rapidly deploying dozens to
+  hundreds of machines over a LAN. It distributes disk images peer-to-peer with
+  the BitTorrent protocol and writes directly to raw disk partitions, so
+  deployment time stays roughly flat as clients are added because every client
+  also seeds. It uses partclone to capture only the used filesystem blocks, and
+  ships inside Clonezilla as its Lite Server Mode.
+repository-code: 'https://github.com/tjjh89017/ezio'
+url: 'https://github.com/tjjh89017/ezio'
+license: GPL-2.0-only
+keywords:
+  - bittorrent
+  - peer-to-peer
+  - disk-imaging
+  - massive-deployment
+  - clonezilla
+  - partclone
+references:
+  - type: article
+    title: 'A BitTorrent Mechanism-Based Solution for Massive System Deployment'
+    journal: IEEE Access
+    year: 2021
+    volume: 9
+    start: 21043
+    end: 21058
+    doi: 10.1109/ACCESS.2021.3052525
+    authors:
+      - given-names: Steven J. H.
+        family-names: Shiau
+      - given-names: Yu-Chiang
+        family-names: Huang
+      - given-names: Yu-Chin
+        family-names: Tsai
+      - given-names: Chen-Kai
+        family-names: Sun
+      - given-names: Ching-Hsuan
+        family-names: Yen
+      - given-names: Chi-Yo
+        family-names: Huang
+  - type: article
+    title: 'A Novel Massive Deployment Solution Based on the Peer-to-Peer Protocol'
+    journal: Applied Sciences
+    year: 2019
+    volume: 9
+    issue: '2'
+    start: 296
+    doi: 10.3390/app9020296
+    authors:
+      - given-names: Steven J. H.
+        family-names: Shiau
+      - given-names: Yu-Chiang
+        family-names: Huang
+      - given-names: Ching-Hsuan
+        family-names: Yen
+      - given-names: Yu-Chin
+        family-names: Tsai
+      - given-names: Chen-Kai
+        family-names: Sun
+      - given-names: Jer-Nan
+        family-names: Juang
+      - given-names: Chi-Yo
+        family-names: Huang
+      - given-names: Ching-Chun
+        family-names: Huang
+      - given-names: Shih-Kun
+        family-names: Huang


### PR DESCRIPTION
## What

Adds a machine-readable citation record. GitHub renders it as the **"Cite this repository"** button in the sidebar (APA + BibTeX, no external registration needed); Zenodo and Software Heritage also read it automatically if the repo is ever archived there.

Software authorship is **Yu-Chiang Huang**.

Rendered output:

```
Huang Y. EZIO URL: https://github.com/tjjh89017/ezio
```

```bibtex
@misc{YourReferenceHere,
  author = {Huang, Yu-Chiang},
  title = {EZIO},
  url = {https://github.com/tjjh89017/ezio}
}
```

## Notes on the choices made

**The two papers are under `references:`, not `preferred-citation:`.** Setting `preferred-citation` would make the Cite button emit the IEEE Access paper (Shiau et al.) instead of the software. Keeping it under `references` means the button cites the software while the papers stay in the metadata. If you would rather have the paper be the canonical citation, it is a one-line change — move the IEEE Access block up and rename the key.

**Paper metadata came from Crossref, not from hand-typing.** Author lists, volume/page ranges and DOIs were pulled from the Crossref API, so the reference blocks carry the papers' full published author lists — those are a record of what was published and are intentionally left as-is regardless of the software authorship above. `10.1109/ACCESS.2021.3052525` was checked to resolve to `ieeexplore.ieee.org/document/9328243`, the exact document the README already links to. CFF requires an `authors` list on every reference, which is why the full lists appear here even though the README's Publications section deliberately omits them.

**No `version` / `date-released`.** Both are optional and both go stale the moment a tag is pushed — with releases landing every month or two, a wrong version in the citation is worse than no version. Happy to add them plus a bump step in `release.yml` if you would prefer them present.

**`license: GPL-2.0-only`.** The LICENSE file is the plain GPLv2 text with no "or later" election anywhere in the tree and no per-file headers, so `-only` is the conservative reading and matches what GitHub's detector reports. Worth a second look from you since it is the one field here that is a legal statement rather than a fact — say the word and I will switch it to `GPL-2.0-or-later`.

## Verification

`cffconvert --validate` → *Citation metadata are valid according to schema version 1.2.0.*

Independent of #153; the two can merge in either order.