### PR TITLE
ci: pin scorecard-action to v2.4.4

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
The OpenSSF Scorecard workflow has failed on every run since #153 merged:

```
##[error]Unable to resolve action `ossf/scorecard-action@v2`, unable to find version `v2`
```

`ossf/scorecard-action` publishes no floating major tag — its refs are `v2.4.4`, `v2.4.3`, ... only. Unlike `actions/checkout`, `github/codeql-action` and `actions/upload-artifact`, which all carry one, so the major-tag convention from #153 has no target here. The job fails during action setup, before any step runs.

Pinned to the full version. Dependabot still covers it: with no floating tag absorbing the patch releases, it will open a PR for `v2.4.5`.

Runs affected: [31379252898](https://github.com/tjjh89017/ezio/actions/runs/31379252898) (push), [31379560295](https://github.com/tjjh89017/ezio/actions/runs/31379560295) (branch_protection_rule).

The README Scorecard badge stays grey until this lands and the workflow completes once on `master`.