### PR TITLE
docs: add maintainer alias to CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,6 +8,7 @@ type: software
 authors:
   - given-names: Yu-Chiang
     family-names: Huang
+    alias: tjjh89017
 abstract: >-
   EZIO is a high-performance disk imaging tool for rapidly deploying dozens to
   hundreds of machines over a LAN. It distributes disk images peer-to-peer with


### PR DESCRIPTION
Follow-up to #154. Records the GitHub handle alongside the author entry:

```yaml
authors:
  - given-names: Yu-Chiang
    family-names: Huang
    alias: tjjh89017
```

`alias` is metadata only — it does not appear in the rendered citation, which is unchanged:

```
Huang Y. EZIO URL: https://github.com/tjjh89017/ezio
```

CFF 1.2.0 defines `alias` as a plain string (`{"type": "string", "minLength": 1}`), so it holds one value and a list fails validation. The handle is the useful one to record, since it is unique and resolvable.

`cffconvert --validate` -> *Citation metadata are valid according to schema version 1.2.0.*